### PR TITLE
ci(workflows): push ブランチを main/master/releases に限定

### DIFF
--- a/.github/workflows/ci-scan-all.yml
+++ b/.github/workflows/ci-scan-all.yml
@@ -15,7 +15,9 @@ permissions:
 on:
   push:
     branches:
-      - "**"
+      - "main"
+      - "master"
+      - "releases"
 
   pull_request:
     branches:


### PR DESCRIPTION
## ✨ Overview

This PR adjusts the CI scanning workflow so that pushes no longer trigger scans on *all* branches.  
The previous setting (`"**"`) caused unnecessary executions, including on temporary and feature branches.  
To reduce noise and resource use, the scan now runs only on stable branches:

- `main`
- `master`
- `releases`

---

## 🔧 Changes

- [x] Updated **.github/workflows/ci-scan-all.yml**  
  - Modified `on.push.branches` from `"**"` to `["main", "master", "releases"]`

---

## 📂 Related Issues

> *(none specified — add if needed)*

---

## ✅ Checklist

- [ ] Documentation is updated (if applicable)
- [x] PR title follows Conventional Commits
- [x] Descriptions and examples are clear

---

## 💬 Additional Notes

None.
