### PR TITLE
deps(package): update CI actions and zenn-cli

### DIFF
--- a/.github/workflows/ci-lint-articles.yaml
+++ b/.github/workflows/ci-lint-articles.yaml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
           fetch-depth: 1
@@ -57,18 +57,18 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Setup node
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           version: 10
 
       - name: Restore cache
         id: cache-restore
-        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: ${{ runner.os }}-cache
           path: |
@@ -97,7 +97,7 @@ jobs:
 
       - name: Always save cache
         id: cache-save
-        uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: ${{ steps.cache-restore.outputs.cache-primary-key }}
           path: |

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "lint:markdown": "pnpm exec markdownlint-cli2 --config ./configs/.markdownlint-cli2.yaml "
   },
   "devDependencies": {
-    "zenn-cli": "^0.4.5"
+    "zenn-cli": "^0.5.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       zenn-cli:
-        specifier: ^0.4.5
-        version: 0.4.5
+        specifier: ^0.5.1
+        version: 0.5.1
 
 packages:
 
@@ -59,8 +59,8 @@ packages:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
 
-  zenn-cli@0.4.5:
-    resolution: {integrity: sha512-lrG5Bb8j8jhVKRLE1T6Fe/wYV+jBDaRZFHzDatS/tcxcoV1oNaK812PeXYr2rtvH77trZaIag6fYltGXAIN0oA==}
+  zenn-cli@0.5.1:
+    resolution: {integrity: sha512-4F5lfW9RZTjPr8CuwUSoCnxcSBYcjJBFas+FombLF/rnOlrJia73b1Jn8laYhWwAmz4cYgJ3OvBApTh80NEHnw==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -104,7 +104,7 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
 
-  zenn-cli@0.4.5:
+  zenn-cli@0.5.1:
     dependencies:
       open: 10.2.0
       package-manager-detector: 1.6.0


### PR DESCRIPTION
## Overview

**Summary**
Updates GitHub Actions versions and bumps zenn-cli to the latest release.

**Background / Motivation**
Routine dependency update to keep CI actions and the zenn-cli package current. zenn-cli 0.5.1 requires Node.js >=22, which aligns with the existing `node-version: 22` setting in the workflow.

## Changes

### Core Changes

- `package.json`: bump `zenn-cli` from `^0.4.5` to `^0.5.1`
- `pnpm-lock.yaml`: update lockfile entry to `zenn-cli@0.5.1`

### CI/CD Changes

- `.github/workflows/ci-lint-articles.yaml`: update action versions
  - `actions/checkout`: v6.0.2 → v6.0.3
  - `actions/setup-node`: v6.2.0 → v6.4.0
  - `pnpm/action-setup`: v4.2.0 → v6.0.8
  - `actions/cache/restore` and `actions/cache/save`: v5.0.3 → v5.0.5

### Test Updates

N/A

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [x] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [ ] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

zenn-cli 0.5.1 introduces a Node.js >=22 engine requirement. The CI workflow already pins `node-version: 22`, so no additional changes are needed.
