### PR TITLE
config(commitlint): add publish commit type

### DIFF
--- a/.github/workflows/ci-lint-articles.yaml
+++ b/.github/workflows/ci-lint-articles.yaml
@@ -62,7 +62,7 @@ jobs:
           node-version: 22
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 10
 

--- a/configs/commitlint.config.js
+++ b/configs/commitlint.config.js
@@ -34,6 +34,7 @@ export default {
       'ci', // CI/CD related change
 
       // === Custom additions ===
+      'publish', // (custom) For publish articles
       'config', // (custom) For configuration changes
       'release', // (custom) For releases
       'merge', // (custom) For merge commits, especially when conflict resolution involved


### PR DESCRIPTION
## Overview

**Summary**
Adds `publish` as a custom commit type to commitlint configuration.

**Background / Motivation**
The `publish` type represents Zenn article publishing operations. Without this type, publishing commits could not be labeled correctly, reducing clarity in commit history.

## Changes

### Core Changes

- `configs/commitlint.config.js`: add `publish` to the custom type list

### CI Updates

- `.github/workflows/ci-lint-articles.yaml`: bump pnpm/action-setup from v6.0.8 to v6.0.9

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [ ] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [ ] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

`publish` is an additive change only. No existing types are modified, so there are no breaking changes.
