### PR TITLE
ci(workflows): migrate lint workflow to composite actions

### DIFF
--- a/.github/workflows/ci-lint-articles.yaml
+++ b/.github/workflows/ci-lint-articles.yaml
@@ -1,15 +1,19 @@
-# src: .github/workflows/ci-lint.yaml
+# src: .github/workflows/ci-lint-articles.yaml
 # @(#) : lint document use textlint, markdownlint
 #
 # Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 #
 # This software is released under the MIT License.
 # https://opensource.org/licenses/MIT
-## @(#) : ci-lint / lint new articles
+## @(#) : ci-lint-articles / lint new articles
 
 name: "CI Lint Articles"
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - "**/*.md"
   pull_request:
     branches: [main]
     paths:
@@ -25,82 +29,41 @@ jobs:
       contents: read
 
     steps:
-      - name: Checkout repository
+      - id: checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          fetch-depth: 0
           persist-credentials: false
-          fetch-depth: 1
 
-      - name: Debug workspace
-        run: |
-          pwd
-          ls -la
-          ls -la scripts || true
-
-      - name: Fetch main repository
-        run: |
-          git fetch origin main
-
-      - name: Get changed Markdown files
-        id: changed-md
-        run: |
-          head_sha="$(git rev-parse HEAD)"
-          base_sha="$(git rev-parse origin/main)"
-
-          files=$(git diff --diff-filter=AM --name-only "${base_sha}" "${head_sha}" -- '**/*.md')
-          printf "changed:\n%s\n" "$files"
-
-          {
-            echo "files<<EOF"
-            echo "$files"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Setup node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - id: validate-env
+        uses: aglabo/ci-platform/.github/actions/ca-validate-environment@f4e8d971ee9093901df0255154e643fd1f2ee10d # v0.3.1+
         with:
-          node-version: 22
+          actions-type: read
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          version: 10
-
-      - name: Restore cache
-        id: cache-restore
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          key: ${{ runner.os }}-cache
-          path: |
-            node_modules
-            ~/.pnpm-store
-            .cache/*
-
-      - name: Install linters
-        run: |
-          chmod +x ./scripts/install-doc-tools.sh
-          ./scripts/install-doc-tools.sh
-
-      - name: Lint text
-        if: ${{ steps.changed-md.outputs.files != '' }}
+      - id: resolve-sha
         env:
-          changed_files: "${{ steps.changed-md.outputs.files }}"
-        run: |
-          pnpm run lint:text "${changed_files}"
+          EVENT_NAME: ${{ github.event_name }}
+        run: bash .github/workflows/scripts/resolve-sha.sh
 
-      - name: Lint markdown
-        if: ${{ steps.changed-md.outputs.files != '' }}
-        env:
-          changed_files: "${{ steps.changed-md.outputs.files }}"
-        run: |
-          pnpm run lint:markdown "${changed_files}"
-
-      - name: Always save cache
-        id: cache-save
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - id: changed-files
+        if: steps.resolve-sha.outputs.skip != 'true'
+        uses: aglabo/ci-platform/.github/actions/ca-get-changed-files@f4e8d971ee9093901df0255154e643fd1f2ee10d # v0.3.1+
         with:
-          key: ${{ steps.cache-restore.outputs.cache-primary-key }}
-          path: |
-            node_modules
-            ~/.pnpm-store
-            .cache/*
+          pattern: "**/*.md"
+          before-sha: ${{ env.BEFORE_SHA }}
+          after-sha: ${{ env.AFTER_SHA }}
+
+      - id: setup-repo
+        if: steps.resolve-sha.outputs.skip != 'true'
+        uses: aglabo/ci-platform/.github/actions/ca-setup-repo@f4e8d971ee9093901df0255154e643fd1f2ee10d # v0.3.1+
+        with:
+          repo: aglabo/agla-doc-tools
+          path: ./.tools/agla-doc-tools
+          ref: bec772fc1d22fbf43fd57ef3a71f7972b83b3e24 # v0.1.1
+
+      - id: lint
+        if: steps.resolve-sha.outputs.skip != 'true'
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.files }}
+          CHANGED_COUNT: ${{ steps.changed-files.outputs.count }}
+        run: bash .github/workflows/scripts/lint.sh

--- a/.github/workflows/scripts/__tests__/unit/ci_lint_articles_yaml.spec.sh
+++ b/.github/workflows/scripts/__tests__/unit/ci_lint_articles_yaml.spec.sh
@@ -1,0 +1,72 @@
+#shellcheck shell=sh
+# .github/workflows/scripts/__tests__/unit/ci_lint_articles_yaml.spec.sh
+# @(#) : ShellSpec unit tests for .github/workflows/ci-lint-articles.yaml structure
+#
+# Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+# ─── Internal Helpers ──────────────────────────────────────────────────────────
+
+_YAML="${SHELLSPEC_PROJECT_ROOT}/.github/workflows/ci-lint-articles.yaml"
+
+Describe 'ci-lint-articles.yaml'
+  Describe 'Given: the workflow YAML file exists'
+    Describe 'When: the steps list is inspected'
+      Describe 'Then: Task T-00-01 - YAML workflow structure'
+        It 'T-00-01-01: has 6 steps in correct order'
+          When run bash -c "yq '.jobs.lint-on-github.steps[].id' \"$_YAML\" | tr '\n' ' ' | grep -qE '^checkout validate-env resolve-sha changed-files setup-repo lint[[:space:]]*\$' && echo ok"
+          The output should equal "ok"
+        End
+
+        It 'T-00-01-02: checkout step has persist-credentials: false'
+          When run bash -c "yq '.jobs.lint-on-github.steps[] | select(.id == \"checkout\") | .with[\"persist-credentials\"]' \"$_YAML\" | grep -qx 'false' && echo ok"
+          The output should equal "ok"
+        End
+
+        It 'T-00-01-03a: changed-files step has skip propagation if condition'
+          When run bash -c "yq '.jobs.lint-on-github.steps[] | select(.id == \"changed-files\") | .if' \"$_YAML\" | grep -qF \"steps.resolve-sha.outputs.skip != 'true'\" && echo ok"
+          The output should equal "ok"
+        End
+
+        It 'T-00-01-03b: setup-repo step has skip propagation if condition'
+          When run bash -c "yq '.jobs.lint-on-github.steps[] | select(.id == \"setup-repo\") | .if' \"$_YAML\" | grep -qF \"steps.resolve-sha.outputs.skip != 'true'\" && echo ok"
+          The output should equal "ok"
+        End
+
+        It 'T-00-01-03c: lint step has skip propagation if condition'
+          When run bash -c "yq '.jobs.lint-on-github.steps[] | select(.id == \"lint\") | .if' \"$_YAML\" | grep -qF \"steps.resolve-sha.outputs.skip != 'true'\" && echo ok"
+          The output should equal "ok"
+        End
+      End
+
+      Describe 'Then: Task T-00-02 - Action SHA pinning'
+        It 'T-00-02-01: actions/checkout is pinned to commit SHA df4cb1c'
+          When run bash -c "yq '.jobs.lint-on-github.steps[] | select(.id == \"checkout\") | .uses' \"$_YAML\" | grep -qF 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' && echo ok"
+          The output should equal "ok"
+        End
+
+        It 'T-00-02-02: ca-validate-environment is pinned to commit SHA f4e8d97'
+          When run bash -c "yq '.jobs.lint-on-github.steps[] | select(.id == \"validate-env\") | .uses' \"$_YAML\" | grep -qF 'ca-validate-environment@f4e8d971ee9093901df0255154e643fd1f2ee10d' && echo ok"
+          The output should equal "ok"
+        End
+
+        It 'T-00-02-03: ca-get-changed-files is pinned to commit SHA f4e8d97'
+          When run bash -c "yq '.jobs.lint-on-github.steps[] | select(.id == \"changed-files\") | .uses' \"$_YAML\" | grep -qF 'ca-get-changed-files@f4e8d971ee9093901df0255154e643fd1f2ee10d' && echo ok"
+          The output should equal "ok"
+        End
+
+        It 'T-00-02-04: ca-setup-repo is pinned to commit SHA f4e8d97'
+          When run bash -c "yq '.jobs.lint-on-github.steps[] | select(.id == \"setup-repo\") | .uses' \"$_YAML\" | grep -qF 'ca-setup-repo@f4e8d971ee9093901df0255154e643fd1f2ee10d' && echo ok"
+          The output should equal "ok"
+        End
+
+        It 'T-00-02-05: setup-repo with.ref is pinned to commit SHA bec772f'
+          When run bash -c "yq '.jobs.lint-on-github.steps[] | select(.id == \"setup-repo\") | .with.ref' \"$_YAML\" | grep -qF 'bec772fc1d22fbf43fd57ef3a71f7972b83b3e24' && echo ok"
+          The output should equal "ok"
+        End
+      End
+    End
+  End
+End

--- a/.github/workflows/scripts/__tests__/unit/lint_sh.spec.sh
+++ b/.github/workflows/scripts/__tests__/unit/lint_sh.spec.sh
@@ -1,0 +1,256 @@
+#shellcheck shell=sh
+# .github/workflows/scripts/__tests__/unit/lint_sh.spec.sh
+# @(#) : ShellSpec unit tests for .github/workflows/scripts/lint.sh
+#
+# Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+# ─── Internal Helpers ──────────────────────────────────────────────────────────
+
+_SCRIPT="${SHELLSPEC_PROJECT_ROOT}/.github/workflows/scripts/lint.sh"
+
+Describe 'lint.sh'
+
+  Describe 'Given: CHANGED_COUNT is non-numeric'
+    setup_non_numeric() {
+      STUB_DIR=$(mktemp -d)
+      export STUB_DIR
+      printf '#!/bin/sh\necho "textlint $*" >> "%s/calls.log"\nexit 0\n' "$STUB_DIR" > "$STUB_DIR/textlint"
+      printf '#!/bin/sh\necho "markdownlint $*" >> "%s/calls.log"\nexit 0\n' "$STUB_DIR" > "$STUB_DIR/markdownlint"
+      chmod +x "$STUB_DIR/textlint" "$STUB_DIR/markdownlint"
+      export PATH="$STUB_DIR:$PATH"
+      export CHANGED_COUNT="abc"
+      export CHANGED_FILES=""
+    }
+    cleanup_non_numeric() {
+      rm -rf "$STUB_DIR"
+    }
+    Before 'setup_non_numeric'
+    After 'cleanup_non_numeric'
+
+    Describe 'When: lint.sh is executed'
+      Describe 'Then: Task T-04-02 - CHANGED_COUNT non-numeric causes failure'
+        It 'T-04-02-02: exits with non-zero status when CHANGED_COUNT is not a number'
+          When run script "$_SCRIPT"
+          The status should not eq 0
+          The stderr should include "error"
+        End
+      End
+    End
+  End
+
+  Describe 'Given: CHANGED_COUNT is 0'
+    setup_count_zero() {
+      STUB_DIR=$(mktemp -d)
+      export STUB_DIR
+      printf '#!/bin/sh\necho "textlint $*" >> "%s/calls.log"\nexit 0\n' "$STUB_DIR" > "$STUB_DIR/textlint"
+      printf '#!/bin/sh\necho "markdownlint $*" >> "%s/calls.log"\nexit 0\n' "$STUB_DIR" > "$STUB_DIR/markdownlint"
+      chmod +x "$STUB_DIR/textlint" "$STUB_DIR/markdownlint"
+      export PATH="$STUB_DIR:$PATH"
+      export CHANGED_COUNT="0"
+      export CHANGED_FILES=""
+    }
+    cleanup_count_zero() {
+      rm -rf "$STUB_DIR"
+    }
+    Before 'setup_count_zero'
+    After 'cleanup_count_zero'
+
+    Describe 'When: lint.sh is executed'
+      Describe 'Then: Task T-04-03 - skip scenarios'
+        It 'T-04-03-01: exits with status 0 when count is 0'
+          When run script "$_SCRIPT"
+          The status should eq 0
+          The output should include "warning"
+          The stderr should include "warning"
+        End
+
+        It 'T-04-03-01: outputs a warning message when count is 0'
+          When run script "$_SCRIPT"
+          The output should include "warning"
+          The stderr should include "warning"
+        End
+      End
+    End
+  End
+
+  Describe 'Given: CHANGED_FILES has two existing files with newline separator'
+    setup_two_files() {
+      STUB_DIR=$(mktemp -d)
+      export STUB_DIR
+      TMP_FILE_A=$(mktemp --suffix=.md)
+      TMP_FILE_B=$(mktemp --suffix=.md)
+      printf '# test a\n' > "$TMP_FILE_A"
+      printf '# test b\n' > "$TMP_FILE_B"
+      export TMP_FILE_A TMP_FILE_B
+
+      printf '#!/bin/sh\nprintf "textlint %%s\\n" "$*" >> "%s/calls.log"\nexit 0\n' "$STUB_DIR" > "$STUB_DIR/textlint"
+      printf '#!/bin/sh\nprintf "markdownlint %%s\\n" "$*" >> "%s/calls.log"\nexit 0\n' "$STUB_DIR" > "$STUB_DIR/markdownlint"
+      chmod +x "$STUB_DIR/textlint" "$STUB_DIR/markdownlint"
+      export PATH="$STUB_DIR:$PATH"
+
+      CHANGED_FILES="${TMP_FILE_A}
+${TMP_FILE_B}"
+      export CHANGED_FILES
+      export CHANGED_COUNT="2"
+    }
+    cleanup_two_files() {
+      rm -f "$TMP_FILE_A" "$TMP_FILE_B"
+      rm -rf "$STUB_DIR"
+    }
+    Before 'setup_two_files'
+    After 'cleanup_two_files'
+
+    Describe 'When: lint.sh is executed'
+      Describe 'Then: Task T-04-00 - newline-to-space conversion'
+        It 'T-04-00-01: textlint is called once with both files'
+          When run script "$_SCRIPT"
+          The status should eq 0
+          The contents of file "$STUB_DIR/calls.log" should include "textlint"
+          The contents of file "$STUB_DIR/calls.log" should include "$TMP_FILE_A"
+          The contents of file "$STUB_DIR/calls.log" should include "$TMP_FILE_B"
+        End
+      End
+
+      Describe 'Then: Task T-04-01 - lint execution on existing files'
+        It 'T-04-01-01: textlint is called with --config configs/textlintrc.yaml'
+          When run script "$_SCRIPT"
+          The status should eq 0
+          The contents of file "$STUB_DIR/calls.log" should include "--config configs/textlintrc.yaml"
+        End
+
+        It 'T-04-01-02: markdownlint is called with --config configs/.markdownlint-cli2.yaml'
+          When run script "$_SCRIPT"
+          The status should eq 0
+          The contents of file "$STUB_DIR/calls.log" should include "--config configs/.markdownlint-cli2.yaml"
+        End
+      End
+    End
+  End
+
+  Describe 'Given: one file deleted, one file exists'
+    setup_one_deleted() {
+      STUB_DIR=$(mktemp -d)
+      export STUB_DIR
+      TMP_FILE=$(mktemp --suffix=.md)
+      printf '# test\n' > "$TMP_FILE"
+      export TMP_FILE
+      DELETED_FILE="/nonexistent/deleted_$(date +%s).md"
+      export DELETED_FILE
+
+      printf '#!/bin/sh\nprintf "textlint %%s\\n" "$*" >> "%s/calls.log"\nexit 0\n' "$STUB_DIR" > "$STUB_DIR/textlint"
+      printf '#!/bin/sh\nprintf "markdownlint %%s\\n" "$*" >> "%s/calls.log"\nexit 0\n' "$STUB_DIR" > "$STUB_DIR/markdownlint"
+      chmod +x "$STUB_DIR/textlint" "$STUB_DIR/markdownlint"
+      export PATH="$STUB_DIR:$PATH"
+
+      CHANGED_FILES="${DELETED_FILE}
+${TMP_FILE}"
+      export CHANGED_FILES
+      export CHANGED_COUNT="2"
+    }
+    cleanup_one_deleted() {
+      rm -f "$TMP_FILE"
+      rm -rf "$STUB_DIR"
+    }
+    Before 'setup_one_deleted'
+    After 'cleanup_one_deleted'
+
+    Describe 'When: lint.sh is executed'
+      Describe 'Then: Task T-04-03 - skip scenarios'
+        It 'T-04-03-02: logs "deleted -> skip" for missing file'
+          When run script "$_SCRIPT"
+          The status should eq 0
+          The output should include "deleted -> skip"
+        End
+
+        It 'T-04-03-02: only existing file is linted (deleted file not passed to textlint)'
+          When run script "$_SCRIPT"
+          The status should eq 0
+          The output should include "deleted -> skip"
+          The contents of file "$STUB_DIR/calls.log" should include "$TMP_FILE"
+          The contents of file "$STUB_DIR/calls.log" should not include "$DELETED_FILE"
+        End
+      End
+    End
+  End
+
+  Describe 'Given: all files are deleted'
+    setup_all_deleted() {
+      STUB_DIR=$(mktemp -d)
+      export STUB_DIR
+
+      printf '#!/bin/sh\nprintf "textlint %%s\\n" "$*" >> "%s/calls.log"\nexit 0\n' "$STUB_DIR" > "$STUB_DIR/textlint"
+      printf '#!/bin/sh\nprintf "markdownlint %%s\\n" "$*" >> "%s/calls.log"\nexit 0\n' "$STUB_DIR" > "$STUB_DIR/markdownlint"
+      chmod +x "$STUB_DIR/textlint" "$STUB_DIR/markdownlint"
+      export PATH="$STUB_DIR:$PATH"
+
+      export CHANGED_FILES="/nonexistent/a.md
+/nonexistent/b.md"
+      export CHANGED_COUNT="2"
+    }
+    cleanup_all_deleted() {
+      rm -rf "$STUB_DIR"
+    }
+    Before 'setup_all_deleted'
+    After 'cleanup_all_deleted'
+
+    Describe 'When: lint.sh is executed'
+      Describe 'Then: Task T-04-03 - all files deleted'
+        It 'T-04-03-03: exits with status 0 when all files are deleted'
+          When run script "$_SCRIPT"
+          The status should eq 0
+          The output should include "deleted -> skip"
+        End
+
+        It 'T-04-03-03: no linter is called when all files are deleted'
+          When run script "$_SCRIPT"
+          The status should eq 0
+          The output should include "deleted -> skip"
+          The file "$STUB_DIR/calls.log" should not be exist
+        End
+      End
+    End
+  End
+
+  Describe 'Given: one existing file, textlint exits non-zero'
+    setup_textlint_fail() {
+      STUB_DIR=$(mktemp -d)
+      export STUB_DIR
+      TMP_FILE=$(mktemp --suffix=.md)
+      printf '# test\n' > "$TMP_FILE"
+      export TMP_FILE
+
+      printf '#!/bin/sh\nexit 1\n' > "$STUB_DIR/textlint"
+      printf '#!/bin/sh\necho "called" >> "%s/ml.log"\nexit 0\n' "$STUB_DIR" > "$STUB_DIR/markdownlint"
+      chmod +x "$STUB_DIR/textlint" "$STUB_DIR/markdownlint"
+      export PATH="$STUB_DIR:$PATH"
+
+      export CHANGED_FILES="$TMP_FILE"
+      export CHANGED_COUNT="1"
+    }
+    cleanup_textlint_fail() {
+      rm -f "$TMP_FILE"
+      rm -rf "$STUB_DIR"
+    }
+    Before 'setup_textlint_fail'
+    After 'cleanup_textlint_fail'
+
+    Describe 'When: lint.sh is executed'
+      Describe 'Then: Task T-04-02 - fail-fast behavior'
+        It 'T-04-02-01: exits with non-zero status when textlint fails'
+          When run script "$_SCRIPT"
+          The status should not eq 0
+        End
+
+        It 'T-04-02-01: markdownlint is not called when textlint fails'
+          When run script "$_SCRIPT"
+          The status should not eq 0
+          The file "$STUB_DIR/ml.log" should not be exist
+        End
+      End
+    End
+  End
+
+End

--- a/.github/workflows/scripts/__tests__/unit/resolve_sha.spec.sh
+++ b/.github/workflows/scripts/__tests__/unit/resolve_sha.spec.sh
@@ -1,0 +1,203 @@
+#shellcheck shell=sh
+# .github/workflows/scripts/__tests__/unit/resolve_sha.spec.sh
+# @(#) : ShellSpec unit tests for .github/workflows/scripts/resolve-sha.sh
+#
+# Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+# ─── Internal Helpers ──────────────────────────────────────────────────────────
+
+_SCRIPT="${SHELLSPEC_PROJECT_ROOT}/.github/workflows/scripts/resolve-sha.sh"
+
+Describe 'resolve-sha.sh'
+  Describe 'Given: workflow_dispatch event with parent commit'
+    setup() {
+      # Create temp files for GITHUB_ENV and GITHUB_OUTPUT
+      GITHUB_ENV=$(mktemp)
+      GITHUB_OUTPUT=$(mktemp)
+      export GITHUB_ENV GITHUB_OUTPUT
+
+      # Create a temp directory for PATH-based git stub
+      STUB_DIR=$(mktemp -d)
+      export STUB_DIR
+
+      # Stub git to return 2 fields (HEAD SHA + parent SHA)
+      printf '#!/bin/sh\necho "abc123def456 parentsha123"\n' > "$STUB_DIR/git"
+      chmod +x "$STUB_DIR/git"
+
+      export PATH="$STUB_DIR:$PATH"
+      export EVENT_NAME="workflow_dispatch"
+    }
+    cleanup() {
+      rm -f "$GITHUB_ENV" "$GITHUB_OUTPUT"
+      rm -rf "$STUB_DIR"
+    }
+    Before 'setup'
+    After 'cleanup'
+
+    Describe 'When: resolve-sha script is executed'
+      Describe 'Then: Task T-02-01 - workflow_dispatch with parent commit'
+        It 'writes BEFORE_SHA=parentsha123 to GITHUB_ENV'
+          When run script "$_SCRIPT"
+          The contents of file "$GITHUB_ENV" should include "BEFORE_SHA=parentsha123"
+        End
+
+        It 'writes AFTER_SHA=abc123def456 to GITHUB_ENV'
+          When run script "$_SCRIPT"
+          The contents of file "$GITHUB_ENV" should include "AFTER_SHA=abc123def456"
+        End
+
+        It 'writes skip=false to GITHUB_OUTPUT'
+          When run script "$_SCRIPT"
+          The contents of file "$GITHUB_OUTPUT" should include "skip=false"
+        End
+      End
+    End
+  End
+
+  Describe 'Given: workflow_dispatch event with no parent commit (initial commit)'
+    setup_no_parent() {
+      GITHUB_ENV=$(mktemp)
+      GITHUB_OUTPUT=$(mktemp)
+      export GITHUB_ENV GITHUB_OUTPUT
+
+      STUB_DIR=$(mktemp -d)
+      export STUB_DIR
+
+      # Stub git to return 1 field only (no parent)
+      printf '#!/bin/sh\necho "abc123def456"\n' > "$STUB_DIR/git"
+      chmod +x "$STUB_DIR/git"
+
+      export PATH="$STUB_DIR:$PATH"
+      export EVENT_NAME="workflow_dispatch"
+    }
+    cleanup_no_parent() {
+      rm -f "$GITHUB_ENV" "$GITHUB_OUTPUT"
+      rm -rf "$STUB_DIR"
+    }
+    Before 'setup_no_parent'
+    After 'cleanup_no_parent'
+
+    Describe 'When: resolve-sha script is executed'
+      Describe 'Then: Task T-02-04 - initial commit, no parent'
+        It 'writes skip=true to GITHUB_OUTPUT'
+          When run script "$_SCRIPT"
+          The stderr should include "warning"
+          The contents of file "$GITHUB_OUTPUT" should include "skip=true"
+        End
+
+        It 'exits with status 0'
+          When run script "$_SCRIPT"
+          The stderr should include "warning"
+          The status should be success
+        End
+
+        It 'outputs a warning message'
+          When run script "$_SCRIPT"
+          The stderr should include "warning"
+        End
+      End
+    End
+  End
+
+  Describe 'Given: workflow_dispatch event and git command fails'
+    setup_git_fail() {
+      GITHUB_ENV=$(mktemp)
+      GITHUB_OUTPUT=$(mktemp)
+      export GITHUB_ENV GITHUB_OUTPUT
+
+      STUB_DIR=$(mktemp -d)
+      export STUB_DIR
+
+      # Stub git to exit with non-zero (simulates git failure)
+      printf '#!/bin/sh\nexit 128\n' > "$STUB_DIR/git"
+      chmod +x "$STUB_DIR/git"
+
+      export PATH="$STUB_DIR:$PATH"
+      export EVENT_NAME="workflow_dispatch"
+    }
+    cleanup_git_fail() {
+      rm -f "$GITHUB_ENV" "$GITHUB_OUTPUT"
+      rm -rf "$STUB_DIR"
+    }
+    Before 'setup_git_fail'
+    After 'cleanup_git_fail'
+
+    Describe 'When: resolve-sha script is executed'
+      Describe 'Then: Task T-02-03 - git failure causes job failure'
+        It 'exits with non-zero status'
+          When run script "$_SCRIPT"
+          The status should be failure
+        End
+      End
+    End
+  End
+
+  Describe 'Given: push event'
+    setup_push() {
+      GITHUB_ENV=$(mktemp)
+      GITHUB_OUTPUT=$(mktemp)
+      export GITHUB_ENV GITHUB_OUTPUT
+      export EVENT_NAME="push"
+    }
+    cleanup_push() {
+      rm -f "$GITHUB_ENV" "$GITHUB_OUTPUT"
+    }
+    Before 'setup_push'
+    After 'cleanup_push'
+
+    Describe 'When: resolve-sha script is executed'
+      Describe 'Then: Task T-02-02 - push event with empty SHA'
+        It 'writes BEFORE_SHA= (empty) to GITHUB_ENV'
+          When run script "$_SCRIPT"
+          The contents of file "$GITHUB_ENV" should include "BEFORE_SHA="
+        End
+
+        It 'writes AFTER_SHA= (empty) to GITHUB_ENV'
+          When run script "$_SCRIPT"
+          The contents of file "$GITHUB_ENV" should include "AFTER_SHA="
+        End
+
+        It 'writes skip=false to GITHUB_OUTPUT'
+          When run script "$_SCRIPT"
+          The contents of file "$GITHUB_OUTPUT" should include "skip=false"
+        End
+      End
+    End
+  End
+
+  Describe 'Given: pull_request event'
+    setup_pr() {
+      GITHUB_ENV=$(mktemp)
+      GITHUB_OUTPUT=$(mktemp)
+      export GITHUB_ENV GITHUB_OUTPUT
+      export EVENT_NAME="pull_request"
+    }
+    cleanup_pr() {
+      rm -f "$GITHUB_ENV" "$GITHUB_OUTPUT"
+    }
+    Before 'setup_pr'
+    After 'cleanup_pr'
+
+    Describe 'When: resolve-sha script is executed'
+      Describe 'Then: Task T-02-02 - pull_request event with empty SHA'
+        It 'writes BEFORE_SHA= (empty) to GITHUB_ENV'
+          When run script "$_SCRIPT"
+          The contents of file "$GITHUB_ENV" should include "BEFORE_SHA="
+        End
+
+        It 'writes AFTER_SHA= (empty) to GITHUB_ENV'
+          When run script "$_SCRIPT"
+          The contents of file "$GITHUB_ENV" should include "AFTER_SHA="
+        End
+
+        It 'writes skip=false to GITHUB_OUTPUT'
+          When run script "$_SCRIPT"
+          The contents of file "$GITHUB_OUTPUT" should include "skip=false"
+        End
+      End
+    End
+  End
+End

--- a/.github/workflows/scripts/lint.sh
+++ b/.github/workflows/scripts/lint.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# src: .github/workflows/scripts/lint.sh
+# @(#) : lint articles using textlint and markdownlint
+#
+# Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+set -euo pipefail
+
+# ─── Validate inputs ───────────────────────────────────────────────────────────
+
+if ! printf '%s' "${CHANGED_COUNT:-}" | grep -qE '^[0-9]+$'; then
+  echo "error: CHANGED_COUNT is not a valid number: '${CHANGED_COUNT:-}'" >&2
+  exit 1
+fi
+
+# ─── Skip if no changed files ──────────────────────────────────────────────────
+
+if [ "${CHANGED_COUNT}" -eq 0 ]; then
+  echo "warning: CHANGED_COUNT is 0, no files to lint" >&2
+  echo "warning: CHANGED_COUNT is 0, no files to lint"
+  exit 0
+fi
+
+# ─── Build file list (skip deleted files) ─────────────────────────────────────
+
+_files=""
+while IFS= read -r _file; do
+  [ -z "$_file" ] && continue
+  if [ ! -f "$_file" ]; then
+    echo "deleted -> skip: $_file"
+    continue
+  fi
+  _files="${_files}${_files:+ }${_file}"
+done <<EOF
+${CHANGED_FILES}
+EOF
+
+# ─── Skip if all files were deleted ───────────────────────────────────────────
+
+if [ -z "$_files" ]; then
+  echo "warning: all changed files have been deleted, skipping lint"
+  exit 0
+fi
+
+# ─── Run linters ──────────────────────────────────────────────────────────────
+
+# shellcheck disable=SC2086
+textlint --config configs/textlintrc.yaml ${_files}
+
+# shellcheck disable=SC2086
+markdownlint --config configs/.markdownlint-cli2.yaml ${_files}

--- a/.github/workflows/scripts/resolve-sha.sh
+++ b/.github/workflows/scripts/resolve-sha.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# scripts/resolve-sha.sh
+# @(#) : Resolve BEFORE_SHA and AFTER_SHA for GitHub Actions
+#
+# Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+set -euo pipefail
+
+if [ "${EVENT_NAME:-}" = "workflow_dispatch" ]; then
+  _parents=$(git rev-list --parents -n 1 HEAD)
+  _field_count=$(echo "$_parents" | wc -w)
+
+  if [ "$_field_count" -ge 2 ]; then
+    _after_sha=$(echo "$_parents" | awk '{print $1}')
+    _before_sha=$(echo "$_parents" | awk '{print $2}')
+    echo "BEFORE_SHA=${_before_sha}" >>"${GITHUB_ENV}"
+    echo "AFTER_SHA=${_after_sha}" >>"${GITHUB_ENV}"
+    echo "skip=false" >>"${GITHUB_OUTPUT}"
+  else
+    echo "::warning::No parent commit found. Skipping lint." >&2
+    echo "skip=true" >>"${GITHUB_OUTPUT}"
+    exit 0
+  fi
+else  # other events: PUSH, PullRequest
+  echo "BEFORE_SHA=" >>"${GITHUB_ENV}"
+  echo "AFTER_SHA=" >>"${GITHUB_ENV}"
+  echo "skip=false" >>"${GITHUB_OUTPUT}"
+fi

--- a/docs/.deckrd/workflows/lint-article/implementation/implementation.md
+++ b/docs/.deckrd/workflows/lint-article/implementation/implementation.md
@@ -1,0 +1,208 @@
+---
+id: IMPL-001
+title: "Implementation: ci-lint-articles Composite Action Migration"
+spec: SPEC-001
+req: REQ-001
+status: Draft
+version: 1.0.4
+created: "2026-06-23"
+---
+
+<!-- textlint-disable
+  ja-technical-writing/sentence-length
+  -->
+<!-- markdownlint-disable line-length -->
+
+## 1. Overview
+
+本ドキュメントは `ci-lint-articles.yaml` を composite actions ベースに全面置き換えする実装単位を定義する。
+
+**対象ドキュメント**:
+
+- Spec: `specifications/specifications.md` v1.0.5
+- Req: `requirements/requirements.md` v1.0.6
+
+---
+
+## 2. Implementation Units
+
+### IMPL-001: ci-lint-articles.yaml 全面書き換え
+
+**Commit granularity**: 1 コミット。
+
+#### 2.1 Target File
+
+```text
+.github/workflows/ci-lint-articles.yaml
+```
+
+#### 2.2 Dependency: Action SHA
+
+使用する composite actions の commit SHA:
+
+| Action                    | Repository           | SHA                                        | Comment     |
+| ------------------------- | -------------------- | ------------------------------------------ | ----------- |
+| `actions/checkout`        | `actions/checkout`   | `df4cb1c069e1874edd31b4311f1884172cec0e10` | `# v6.0.3`  |
+| `ca-validate-environment` | `aglabo/ci-platform` | `f4e8d971ee9093901df0255154e643fd1f2ee10d` | `# v0.3.1+` |
+| `ca-get-changed-files`    | `aglabo/ci-platform` | `f4e8d971ee9093901df0255154e643fd1f2ee10d` | `# v0.3.1+` |
+| `ca-setup-repo`           | `aglabo/ci-platform` | `f4e8d971ee9093901df0255154e643fd1f2ee10d` | `# v0.3.1+` |
+
+`ca-setup-repo` の `ref` (agla-doc-tools のチェックアウト SHA):
+
+| Repository              | SHA                                        | Comment    |
+| ----------------------- | ------------------------------------------ | ---------- |
+| `aglabo/agla-doc-tools` | `bec772fc1d22fbf43fd57ef3a71f7972b83b3e24` | `# v0.1.1` |
+
+#### 2.3 Workflow Structure
+
+```text
+triggers:
+  - push: branches=[main], paths=['**/*.md']
+  - pull_request: branches=[main], paths=['**/*.md']
+  - workflow_dispatch
+
+jobs:
+  lint-on-github:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      1. id: checkout
+         uses: actions/checkout@df4cb1c... # v6.0.3
+         with:
+           fetch-depth: 0
+           persist-credentials: false
+
+      2. id: validate-env
+         uses: aglabo/ci-platform/.github/actions/ca-validate-environment@f4e8d971... # v0.3.1+
+         with: actions-type: read
+
+      3. id: resolve-sha  (run step)
+         初回コミット判定: git rev-list --parents -n 1 HEAD でparent数を取得
+         - workflow_dispatch + parent数 == 0 (初回コミット) ->
+             echo "skip=true" >> $GITHUB_OUTPUT
+             warning log + exit 0
+         - workflow_dispatch + parent数 >= 1 ->
+             echo "BEFORE_SHA=$(git rev-parse HEAD^1)" >> $GITHUB_ENV
+             echo "AFTER_SHA=$(git rev-parse HEAD)"    >> $GITHUB_ENV
+             echo "skip=false" >> $GITHUB_OUTPUT
+         - workflow_dispatch + git コマンド失敗 -> exit non-zero
+         - push / pull_request ->
+             echo "BEFORE_SHA=" >> $GITHUB_ENV
+             echo "AFTER_SHA="  >> $GITHUB_ENV
+             echo "skip=false" >> $GITHUB_OUTPUT
+
+      4. id: changed-files
+         if: steps.resolve-sha.outputs.skip != 'true'
+         uses: aglabo/ci-platform/.github/actions/ca-get-changed-files@f4e8d971... # v0.3.1+
+         with:
+           pattern: '**/*.md'
+           before-sha: ${{ env.BEFORE_SHA }}
+           after-sha:  ${{ env.AFTER_SHA }}
+
+      5. id: setup-repo
+         if: steps.resolve-sha.outputs.skip != 'true'
+         uses: aglabo/ci-platform/.github/actions/ca-setup-repo@f4e8d971... # v0.3.1+
+         with:
+           repo: aglabo/agla-doc-tools
+           path: .tools/agla-doc-tools
+           ref: bec772fc1d22fbf43fd57ef3a71f7972b83b3e24 # v0.1.1
+
+      6. id: lint  (run step)
+         if: steps.resolve-sha.outputs.skip != 'true'
+         env:
+           CHANGED_FILES: ${{ steps.changed-files.outputs.files }}
+           CHANGED_COUNT: ${{ steps.changed-files.outputs.count }}
+         - CHANGED_COUNT が空または非数値の場合 -> exit non-zero（不正出力として扱う）
+         - count == 0 -> warning + exit 0
+         - for each file (printf '%s\n' "$CHANGED_FILES" | while IFS= read -r file):
+             deleted -> "deleted -> skip" log + continue
+             exists  -> textlint -> markdownlint (fail-fast)
+```
+
+#### 2.4 Spec Rule Coverage
+
+| Rule       | Implementation                                                                                                                                                                |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| R-001a/b/c | on: push / pull_request / workflow_dispatch トリガー定義                                                                                                                      |
+| R-001d     | paths フィルターで *.md 以外の push/PR はジョブ起動しない                                                                                                                     |
+| R-002a     | SHA 解決ステップ: `git rev-parse HEAD^1` 成功時に環境変数セット                                                                                                               |
+| R-002b     | SHA 解決ステップ: `git rev-list --parents -n 1 HEAD` で parent 数 == 0 → `skip=true` + warning + exit 0。後続ステップは `if: steps.resolve-sha.outputs.skip != 'true'` で制御 |
+| R-002c     | SHA 解決ステップ: その他 git エラー → exit non-zero                                                                                                                           |
+| R-002d     | push / PR 時は BEFORE_SHA="", AFTER_SHA="" で自動解決を委譲                                                                                                                   |
+| R-003      | ca-validate-environment を checkout 直後・他ステップより前に配置                                                                                                              |
+| R-004a/b   | ca-get-changed-files に before-sha / after-sha を渡す                                                                                                                         |
+| R-004c     | before-sha オールゼロ時のフォールバックは ca-get-changed-files が処理                                                                                                         |
+| R-005a     | count == 0 の場合 warning ログ + exit 0                                                                                                                                       |
+| R-005b     | outputs.files を展開して各ファイルにループ                                                                                                                                    |
+| R-005c     | `[ -f "$file" ]` チェック: false → "deleted -> skip" + continue                                                                                                               |
+| R-005d     | `textlint --config configs/textlintrc.yaml $FILES` を実行                                                                                                                     |
+| R-005e     | `markdownlint-cli2 --config configs/.markdownlint-cli2.yaml "$file"` を実行                                                                                                   |
+| R-005f     | textlint / markdownlint 失敗時は即 exit non-zero (fail-fast)                                                                                                                  |
+
+#### 2.5 Implementation Notes
+
+- uses: パス形式: `aglabo/ci-platform/.github/actions/<action-name>@<SHA>` の形式で step-level で呼び出す
+- ステップ間の環境変数受け渡し: `echo "VAR=value" >> $GITHUB_ENV` で書き込み、次ステップで `${{ env.VAR }}` として参照する
+- ca-get-changed-files の outputs 参照: step `id: changed-files` を設定し、lint ステップで `${{ steps.changed-files.outputs.files }}` / `${{ steps.changed-files.outputs.count }}` を `env:` 経由で渡す
+- セキュリティ: `actions/checkout` に `persist-credentials: false` を設定する。lint ツールは `textlint` と `markdownlint-cli2` を直接実行するため、PR 内スクリプト変更の影響を受けない
+- `ca-setup-repo` の `repo`: `aglabo/agla-doc-tools`、`path`: `.tools/agla-doc-tools`、`ref`: `bec772fc1d22fbf43fd57ef3a71f7972b83b3e24 # v0.1.1`
+- `ca-setup-repo` は `bin/` を PATH に追加するため、`markdownlint-cli2` コマンドは `ca-setup-repo` 完了後にそのまま呼び出せる
+- 初回コミット判定: `git rev-list --parents -n 1 HEAD` の出力を空白で分割し、フィールド数が 1（親なし）なら初回コミットと判定する。exit code 128 による判定は他の git エラーと区別できないため使わない
+- スキップの伝播: resolve-sha ステップが初回コミットを検出した場合、`echo "skip=true" >> $GITHUB_OUTPUT` で出力し、後続の changed-files / setup-repo / lint 各ステップに `if: steps.resolve-sha.outputs.skip != 'true'` を付与してスキップさせる
+- outputs.files の展開: `echo "$CHANGED_FILES"` ではなく `printf '%s\n' "$CHANGED_FILES"` を使い、先頭ハイフンやオプション風文字列の誤解釈を防ぐ
+- CHANGED_COUNT の型チェック: lint ステップ内で `[[ "$CHANGED_COUNT" =~ ^[0-9]+$ ]]` で数値検証し、不正値の場合は exit non-zero とする
+- GitHub Actions の `run:` ブロックは `bash --noprofile --norc -eo pipefail` で実行されるため、fail-fast（R-005f）は `set -e` を明示しなくても動作する
+
+---
+
+## 3. Commit Plan
+
+| # | File                                      | Type   | Message                                                |
+| - | ----------------------------------------- | ------ | ------------------------------------------------------ |
+| 1 | `.github/workflows/ci-lint-articles.yaml` | `feat` | `feat(ci): migrate lint-articles to composite actions` |
+
+**Commit message body** (Conventional Commits + Deckrd linkage):
+
+```text
+feat(ci): migrate lint-articles to composite actions
+
+- Add push trigger for main branch *.md changes
+- Add workflow_dispatch trigger with SHA resolution
+- Replace inline steps with ca-validate-environment / ca-get-changed-files / ca-setup-repo
+- Add deleted-file skip and fail-fast lint execution
+
+Implements: IMPL-001
+Spec: SPEC-001
+Req: REQ-001
+```
+
+---
+
+## 4. Verification Criteria
+
+実装完了の判定条件:
+
+| # | Criterion                                                                     | How to Verify                          |
+| - | ----------------------------------------------------------------------------- | -------------------------------------- |
+| 1 | YAML 構文が正しい                                                             | `actionlint` / `yamllint` でエラーなし |
+| 2 | fetch-depth が 0 に設定されている                                             | yaml 内を目視確認                      |
+| 3 | ca-validate-environment が checkout の直後に配置されている                    | ステップ順序を目視確認                 |
+| 4 | 全 Action が commit SHA で固定されている                                      | `@SHA # vX.Y.Z` コメント形式を目視確認 |
+| 5 | SHA 解決ステップが R-002a/b/c/d を網羅している                                | スクリプトロジックを目視確認           |
+| 6 | lint ステップが count==0 スキップ・削除済みスキップ・fail-fast を実装している | スクリプトロジックを目視確認           |
+| 7 | push / PR / workflow_dispatch の各トリガーが正しく設定されている              | yaml を目視確認                        |
+
+---
+
+## 5. Change History
+
+| Date       | Version | Description                                                                                                                                                                     |
+| ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-06-23 | 1.0.0   | Initial draft                                                                                                                                                                   |
+| 2026-06-23 | 1.0.1   | explore review 対応: agla-doc-tools SHA 確定 (v0.1.0) 、path `.tools/agla-doc-tools` 追加、markdownlint-cli2 PATH 経路を明記                                                    |
+| 2026-06-23 | 1.0.2   | explore review (2nd) 対応: uses: パス形式・GITHUB_ENV 受け渡し・outputs 参照方式・step id を Section 2.3/2.5 に追記                                                             |
+| 2026-06-23 | 1.0.3   | Codex risk review 対応: 初回コミット判定を exit code 128 から git rev-list --parents に変更、skip=true による後続ステップ制御、printf '%s\n' 展開、CHANGED_COUNT 数値検証を追加 |
+| 2026-06-23 | 1.0.4   | Codex balanced review 対応: checkout に persist-credentials: false 追加。Composite Action 契約・実行環境検証は自作 action / ca-validate-environment で対応済みとして記録        |

--- a/docs/.deckrd/workflows/lint-article/requirements/requirements.md
+++ b/docs/.deckrd/workflows/lint-article/requirements/requirements.md
@@ -1,0 +1,349 @@
+---
+title: "Requirements: ci-lint-articles Composite Action Migration"
+module: "workflows/lint-article"
+status: Draft
+version: 1.0.6
+created: "2026-06-22"
+---
+
+<!-- textlint-disable
+  ja-technical-writing/sentence-length
+  -->
+<!-- markdownlint-disable line-length -->
+
+> **Normative Statement**
+> This document defines binding requirements.
+> Implementations MUST conform to this document.
+> RFC 2119 keywords apply to this document only.
+
+## 1. Overview
+
+### 1.1 Purpose
+
+`ci-lint-articles.yaml` を ci-platform の composite actions (`ca-validate-environment`、`ca-get-changed-files`、`ca-setup-repo`) を使った実装に作り直す。
+あわせて `push` トリガーを追加し、PR 時だけでなく main ブランチへの直接 push 時にも Markdown ドキュメントの lint が実行されるようにする。
+
+### 1.2 Scope
+
+- `ci-lint-articles.yaml` の全面的な置き換え
+- `push: branches: [main], paths: ['**/*.md']` トリガーの追加
+- `workflow_dispatch` トリガーの追加 (before-sha = `github.sha^1`、after-sha = `github.sha` で変更ファイルを取得)
+- `ca-get-changed-files` の拡張 (SHA 指定済みの場合はそれを優先使用する動作を追加)
+- `ca-validate-environment` / `ca-get-changed-files` / `ca-setup-repo` の採用
+- `pnpm run lint:text` と `pnpm run lint:markdown` による lint 実行
+
+**Out of Scope**:
+
+- reusable workflow (`ru-*`) の作成
+- 他のワークフローファイルの変更
+- textlint・markdownlint の設定変更
+- lint ルールの追加・変更
+
+## 2. Context
+
+- Target Environment: GitHub Actions (ubuntu-latest)
+- Related Components: `aglabo/ci-platform` (composite actions 提供元) 、`configs/textlintrc.yaml`、`configs/.markdownlint.yaml`
+- Assumptions:
+  - `aglabo/ci-platform` の composite actions は安定しており、`ca-get-changed-files` は push / pull_request どちらのトリガーでも動作する
+  - `ca-get-changed-files` は push イベントでは `github.event.before` (before-sha) と `github.sha` (after-sha) を、pull_request イベントでは PR の base SHA (before-sha) と head SHA (after-sha) を使って変更ファイルリストを出力する
+  - `ca-get-changed-files` は before-sha がオールゼロ (初回 push・新規ブランチ作成時) の場合、自動的に空ツリー SHA にフォールバックしてリポジトリ全ファイルとの差分を返す。caller 側での特別処理は不要
+  - `ca-setup-repo` は Node.js / pnpm のセットアップと `pnpm install` まで行うため、別途インストールステップは不要
+
+### System Context Diagram
+
+```text
+[Developer]    --> +---------------------------+ --> [GitHub Actions Runner]
+                   |   ci-lint-articles.yaml   |
+[GitHub Push]  --> +---------------------------+ --> [textlint / markdownlint]
+                            |         ^
+                            v         |
+               [aglabo/ci-platform composite actions]
+```
+
+## 3. Design Decisions (Summary)
+
+| ID    | Decision                                                                                       | Linked Record |
+| ----- | ---------------------------------------------------------------------------------------------- | ------------- |
+| DR-01 | composite actions を直接呼び出す (reusable workflow なし)                                      | —             |
+| DR-02 | ca-setup-repo で aglabo/ci-platform をセットアップする                                         | —             |
+| DR-03 | push トリガーは main ブランチのみ対象とする                                                    | —             |
+| DR-04 | ca-get-changed-files は SHA 指定済みの場合はそれを優先し、未指定時のみイベントから自動取得する | —             |
+| DR-07 | 使用するすべての Action を commit SHA で固定する (サプライチェーンリスク対策)                  | —             |
+| DR-05 | REQ-NF-001 を MUST に昇格、REQ-NF-003 を REQ-C-001 に統合                                      | —             |
+| DR-06 | workflow_dispatch トリガーを REQ-F-007 として独立した要件に分離                                | —             |
+
+## 4. Functional Requirements
+
+### REQ-F-001: push トリガーでの lint 実行
+
+- EARS Type: event-driven
+
+```text
+GIVEN main ブランチへの push が発生し、変更ファイルに *.md が含まれる
+  WHEN GitHub Actions の push イベントが発火する
+THEN the system SHALL lint:text および lint:markdown を実行し、エラーがある場合はワークフローを失敗させる。
+```
+
+**Rationale**: PR 時だけでなく main への直接 push 時も lint を保証するため。
+
+**Acceptance Criteria**:
+
+| AC ID  | Scenario                                      |
+| ------ | --------------------------------------------- |
+| AC-001 | main への push で lint が実行される           |
+| AC-002 | *.md 以外の変更のみでは lint がスキップされる |
+
+### REQ-F-002: pull_request トリガーでの lint 実行 (既存動作の維持)
+
+- EARS Type: event-driven
+
+```text
+GIVEN main ブランチへの pull_request が作成または更新され、変更ファイルに *.md が含まれる
+  WHEN GitHub Actions の pull_request イベントが発火する
+THEN the system SHALL lint:text および lint:markdown を実行し、エラーがある場合はワークフローを失敗させる。
+```
+
+**Rationale**: 既存の PR lint 動作を回帰させないため。
+
+**Acceptance Criteria**:
+
+| AC ID  | Scenario                                      |
+| ------ | --------------------------------------------- |
+| AC-003 | PR 作成時に lint が実行される                 |
+| AC-004 | lint エラーがある場合 PR チェックが失敗になる |
+
+### REQ-F-003: ca-validate-environment による環境検証
+
+- EARS Type: event-driven
+
+```text
+GIVEN GitHub Actions ジョブが開始される
+  WHEN lint ジョブの最初のステップが実行される
+THEN the system SHALL ca-validate-environment を実行し、runner 環境と権限を検証する。
+```
+
+**Rationale**: 実行環境の事前検証によりデバッグを容易にするため。
+
+**Acceptance Criteria**:
+
+| AC ID  | Scenario                           |
+| ------ | ---------------------------------- |
+| AC-005 | 環境検証ステップが最初に実行される |
+
+### REQ-F-004: ca-get-changed-files による変更ファイル取得
+
+- EARS Type: event-driven
+
+```text
+GIVEN push、pull_request、または workflow_dispatch イベントが発生する
+  WHEN 変更ファイルの取得ステップが実行される
+THEN the system SHALL ca-get-changed-files を呼び出して変更された *.md ファイルのリストを取得し、後続のステップで利用可能にする。
+```
+
+**Notes**:
+
+SHA 解決ルール (ca-get-changed-files の動作):
+
+- before-sha / after-sha が指定済みの場合はそれを優先使用する
+- 未指定の場合はイベント種別から自動取得する
+  - push イベント: before-sha = `github.event.before`、after-sha = `github.sha`
+  - pull_request イベント: before-sha = PR base SHA、after-sha = PR head SHA
+
+caller 側の責務:
+
+- workflow_dispatch 時は caller が before-sha = `github.sha^1`、after-sha = `github.sha` を渡す
+
+**Rationale**: 変更されたファイルのみを lint することで実行時間を短縮し、無関係なファイルへの誤検知を防ぐため。
+
+**Acceptance Criteria**:
+
+| AC ID  | Scenario                                                              |
+| ------ | --------------------------------------------------------------------- |
+| AC-006 | 変更された *.md ファイルのみがリストアップされる                      |
+| AC-007 | count == 0 の場合、lint ステップがスキップされ warning で正常終了する |
+
+### REQ-F-005: ca-setup-repo による ci-platform セットアップ
+
+- EARS Type: event-driven
+
+```text
+GIVEN lint ジョブが実行される
+  WHEN 環境セットアップステップが実行される
+THEN the system SHALL ca-setup-repo を使って aglabo/ci-platform リポジトリをチェックアウトし、ツールを PATH に追加する。
+```
+
+**Rationale**: ci-platform の composite actions と関連ツールを利用可能にするため。
+
+**Acceptance Criteria**:
+
+| AC ID  | Scenario                                                  |
+| ------ | --------------------------------------------------------- |
+| AC-008 | ca-setup-repo 実行後に ci-platform ツールが利用可能になる |
+
+### REQ-F-006: pnpm による lint 実行
+
+- EARS Type: event-driven
+
+```text
+GIVEN ca-get-changed-files の count が 1 以上である
+  WHEN lint 実行ステップが動作する
+THEN the system SHALL 変更ファイルリストから存在しないファイルを除外し、
+  残ったファイルを対象に pnpm run lint:text および pnpm run lint:markdown を実行し、
+  結果を GitHub Actions のログに出力する。
+  削除済みファイルはスキップし「deleted → skip」をログに出力する。
+```
+
+```text
+GIVEN ca-get-changed-files の count が 0 である
+  WHEN lint 実行ステップが評価される
+THEN the system SHALL lint ステップをスキップし、warning メッセージをログに出力して正常終了する。
+```
+
+**Rationale**: 既存の lint スクリプトを再利用し、実行方法の一貫性を保つため。変更ファイルがない場合は lint 不要であり、warning で通知して成功扱いとする。削除済みファイルの存在チェックは caller 側の責務とし、`ca-get-changed-files` の責務範囲を超えない設計とする。
+
+**Acceptance Criteria**:
+
+| AC ID  | Scenario                                                           |
+| ------ | ------------------------------------------------------------------ |
+| AC-009 | textlint と markdownlint が両方実行される                          |
+| AC-010 | lint エラー時にワークフローが非ゼロで終了する                      |
+| AC-013 | count == 0 の場合、lint がスキップされ warning ログが出力される    |
+| AC-014 | 削除済みファイルはスキップされ「deleted → skip」がログに出力される |
+
+### REQ-F-007: workflow_dispatch トリガーでの lint 実行
+
+- EARS Type: event-driven
+
+```text
+GIVEN workflow_dispatch イベントが発生する
+  WHEN lint ジョブが起動する
+THEN the system SHALL before-sha に github.sha^1 を、after-sha に github.sha を設定して
+  ca-get-changed-files に渡し、変更された *.md ファイルをリストアップして lint を実行する。
+```
+
+**Rationale**: 手動実行時も最新コミットで変更されたファイルを、lint の対象にするため。
+
+**Acceptance Criteria**:
+
+| AC ID  | Scenario                                                             |
+| ------ | -------------------------------------------------------------------- |
+| AC-011 | workflow_dispatch 実行時に lint が起動する                           |
+| AC-012 | workflow_dispatch 時は github.sha^1 と github.sha の差分が対象になる |
+
+## 5. Non-Functional Requirements
+
+### REQ-NF-001: Maintainability
+
+ワークフローファイルは composite actions の呼び出しを中心に構成しなければならない (MUST) 。lint ロジックをワークフロー内に直接埋め込んではならない。
+
+### REQ-NF-002: Reusability
+
+ci-platform の composite actions は外部リポジトリ (`aglabo/ci-platform`) から参照しなければならない (MUST) 。ワークフロー内にコピーしてはならない。
+
+## 6. Constraints
+
+### REQ-C-001: fetch-depth 制約
+
+`ca-get-changed-files` は git の履歴全体を必要とするため、`actions/checkout` の `fetch-depth` は `0` に設定しなければならない。
+
+### REQ-C-002: push トリガー対象ブランチ
+
+push トリガーは `main` ブランチのみを対象とする。feature ブランチへの push では lint は実行しない。
+
+### REQ-C-003: paths フィルター
+
+push / pull_request トリガーともに `paths: ['**/*.md']` フィルターを設定し、Markdown 以外の変更では lint ジョブを起動しない。
+
+### REQ-C-004: 使用するすべての Action の SHA 固定
+
+ワークフローで使用するすべての Action (`actions/checkout`、`ca-validate-environment`、`ca-get-changed-files`、`ca-setup-repo` を含む) は commit SHA で固定しなければならない。ブランチ名や可変タグの使用は禁止する。
+
+### REQ-C-005: 実装順序
+
+`ci-lint-articles.yaml` の実装に先立ち、`ca-get-changed-files` の SHA 指定優先動作 (DR-04) を先に実装しなければならない。
+
+## 7. User Stories
+
+| Story ID | Role      | Goal                                                     | Reason                                       | Related Requirements |
+| -------- | --------- | -------------------------------------------------------- | -------------------------------------------- | -------------------- |
+| US-001   | 開発者    | main に push した際に自動で lint されたい                | PR を経由しない変更でも品質を保証するため    | REQ-F-001, REQ-F-004 |
+| US-002   | 開発者    | PR 作成時に lint が実行されることを確認したい            | 既存の開発フローを維持するため               | REQ-F-002, REQ-F-004 |
+| US-003   | 開発者    | 変更したファイルだけが lint されてほしい                 | 実行時間を短縮し、無関係なエラーを避けるため | REQ-F-004            |
+| US-004   | CI 管理者 | composite actions を使ったシンプルなワークフローにしたい | 保守性を高め、共通基盤の恩恵を受けるため     | REQ-F-003, REQ-F-005 |
+| US-005   | CI 管理者 | lint ツールのセットアップを ci-platform に統一したい     | セットアップロジックの重複をなくすため       | REQ-F-005            |
+
+## 8. Acceptance Criteria
+
+```gherkin
+# AC-001: main への push で lint が実行される
+# Requirement: REQ-F-001
+Scenario: main への *.md push で lint が起動する
+  Given main ブランチに *.md ファイルを含む push がある
+  When  GitHub Actions の push イベントが発火する
+  Then  ci-lint-articles ワークフローが起動し lint が実行される
+
+# AC-002: *.md 以外の変更では lint がスキップされる
+# Requirement: REQ-F-001
+Scenario: 非 Markdown push では lint がスキップされる
+  Given main ブランチに *.md を含まない push がある
+  When  GitHub Actions の push イベントが発火する
+  Then  ci-lint-articles ワークフローは起動しない (paths フィルターにより)
+
+# AC-003: PR 作成時に lint が実行される
+# Requirement: REQ-F-002
+Scenario: PR 作成時に lint が起動する
+  Given main ブランチへの pull_request が作成された
+  When  GitHub Actions の pull_request イベントが発火する
+  Then  ci-lint-articles ワークフローが起動し lint が実行される
+
+# AC-006: 変更された *.md ファイルのみがリストアップされる
+# Requirement: REQ-F-004
+Scenario: ca-get-changed-files が差分ファイルを正しく返す
+  Given push、pull_request、または workflow_dispatch イベントが発生した
+  When  ca-get-changed-files ステップが実行される
+  Then  変更された *.md ファイルのパスのみが出力される
+
+# AC-010: lint エラー時にワークフローが失敗する
+# Requirement: REQ-F-006
+Scenario: lint エラーでワークフローが失敗する
+  Given 変更された *.md ファイルに lint エラーが含まれる
+  When  pnpm run lint:text または lint:markdown が実行される
+  Then  ワークフローが非ゼロ終了コードで失敗する
+```
+
+## 9. Open Questions
+
+| Question                       | Type | Impact Area | Owner |
+| ------------------------------ | ---- | ----------- | ----- |
+| (未解決の Open Questions なし) | —    | —           | —     |
+
+## 10. Traceability
+
+| REQ ID     | AC IDs                         | Type           |
+| ---------- | ------------------------------ | -------------- |
+| REQ-F-001  | AC-001, AC-002                 | Functional     |
+| REQ-F-002  | AC-003, AC-004                 | Functional     |
+| REQ-F-003  | AC-005                         | Functional     |
+| REQ-F-004  | AC-006, AC-007                 | Functional     |
+| REQ-F-005  | AC-008                         | Functional     |
+| REQ-F-006  | AC-009, AC-010, AC-013, AC-014 | Functional     |
+| REQ-F-007  | AC-011, AC-012                 | Functional     |
+| REQ-NF-001 | N/A                            | Non-Functional |
+| REQ-NF-002 | N/A                            | Non-Functional |
+| REQ-C-001  | N/A                            | Constraint     |
+| REQ-C-002  | N/A                            | Constraint     |
+| REQ-C-003  | N/A                            | Constraint     |
+| REQ-C-004  | N/A                            | Constraint     |
+| REQ-C-005  | N/A                            | Constraint     |
+
+## 11. Change History
+
+| Date       | Version | Description                                                                                                       |
+| ---------- | ------- | ----------------------------------------------------------------------------------------------------------------- |
+| 2026-06-22 | 1.0.0   | Initial release                                                                                                   |
+| 2026-06-22 | 1.0.1   | harden review: REQ-NF-001 を MUST 昇格、REQ-NF-003 削除 (REQ-C-001 統合) 、REQ-F-007 追加 (DR-05、DR-06)          |
+| 2026-06-22 | 1.0.2   | fix review: 要件順序を番号順に整理、MUST 記述スタイル統一、REQ-F-004 Notes 分離、AC-006 に workflow_dispatch 追加 |
+| 2026-06-22 | 1.0.3   | REQ-F-006 に count == 0 スキップ動作を追加 (warning で正常終了) 、AC-007/AC-013 追加                              |
+| 2026-06-22 | 1.0.4   | REQ-C-004 をすべての Action の SHA 固定に拡張 (DR-07 追加)                                                        |
+| 2026-06-22 | 1.0.5   | REQ-F-006 に削除済みファイルの caller 側スキップ処理を追加 (AC-014 追加)                                          |
+| 2026-06-22 | 1.0.6   | Assumptions に初回 push 時の空ツリー SHA フォールバック動作を明記 (ca-get-changed-files が自動処理)               |

--- a/docs/.deckrd/workflows/lint-article/specifications/specifications.md
+++ b/docs/.deckrd/workflows/lint-article/specifications/specifications.md
@@ -1,0 +1,369 @@
+---
+title: "Design Specification: ci-lint-articles Composite Action Migration"
+based-on: requirements.md v1.0.6
+status: Draft
+version: 1.0.5
+created: "2026-06-22"
+---
+
+<!-- textlint-disable
+  ja-technical-writing/sentence-length
+  -->
+<!-- markdownlint-disable line-length -->
+
+> **Normative Statement**
+> This document defines behavioral contracts derived from requirements.
+> Implementations MUST conform to this document.
+> RFC 2119 keywords apply throughout.
+
+## 1. Overview
+
+### 1.1 Purpose
+
+`ci-lint-articles.yaml` を composite actions (`ca-validate-environment`、`ca-get-changed-files`、`ca-setup-repo`) を呼び出す構成に全面置き換えする際の振る舞い仕様を定義する。
+本仕様は「何をするか」を規定し、「どのように実装するか」は規定しない。
+
+### 1.2 Scope
+
+本仕様は以下の振る舞いを対象とする。
+
+- push / pull_request / workflow_dispatch の各トリガーに対する lint ジョブの起動条件
+- 変更ファイルの取得と SHA 解決ロジック
+- lint 実行の前提条件と実行順序
+- count==0 スキップ・削除済みファイルスキップの振る舞い
+- 全 Action の SHA 固定制約
+
+実装詳細 (YAML 構文、具体的な Action バージョン、シェルスクリプトの実装) は対象外とする。
+
+---
+
+## 2. Design Principles
+
+### 2.1 Classification Philosophy
+
+ワークフローは「composite actions の呼び出しシーケンス」として構成される。
+lint ロジックはワークフロー内に直接埋め込まず、外部 action または既存スクリプトへ委譲する。
+
+変更ファイルの有無と削除状態を評価してから lint を実行することで、不要な実行と誤検知を防ぐ。
+
+### 2.2 Design Assumptions
+
+- `ca-get-changed-files` は before-sha / after-sha が空文字の場合、イベント種別 (push / pull_request) から自動的に SHA を解決する
+- `ca-get-changed-files` は before-sha がオールゼロ (初回 push・新規ブランチ) の場合、自動的に空ツリー SHA にフォールバックしてリポジトリ全ファイルとの差分を返す。caller 側での特別処理は不要
+- `ca-setup-repo` (repo: `aglabo/agla-doc-tools`、ref: commit SHA 固定) は Node.js / pnpm のセットアップと `pnpm install` まで行う。別途インストールステップは不要
+- `ca-get-changed-files` の `outputs.files` は改行区切りのファイルパスリストである
+- `markdownlint-cli2` は `ca-setup-repo` によってセットアップされた環境で利用可能になる
+- `outputs.files` のファイルパスリストは、lint 実行ステップ内でシェルスクリプトによりダブルクォートとスペース区切りで展開して lint ツールに渡す
+- 対象 Markdown ファイルのパスには空白・改行・グロブ特殊文字 (`*`、`?`、`[`) を含まないことを前提とする。これらを含むパスの動作は保証しない
+- textlint と markdownlint は fail-fast で実行する。fail-fast はツール単位とし、
+  textlint または markdownlint が非ゼロで終了した場合、ジョブを即時停止する (後続のツール・ファイルは処理しない)
+- エラーの詳細確認と修正はローカル環境で行うことを前提とする
+
+### 2.3 External Design Summary
+
+> **Source**: Phase D (ユーザー確認済み設計方針) および Phase E (外部設計ダイアログ) から導出。
+
+#### Feature Decomposition
+
+| Unit                 | Responsibility                                    | REQ Coverage                    |
+| -------------------- | ------------------------------------------------- | ------------------------------- |
+| environment-validate | runner 環境と権限の事前検証                       | REQ-F-003                       |
+| changed-files-detect | 変更 `*.md` ファイルのリストと件数の取得          | REQ-F-004, REQ-F-007            |
+| repo-setup           | `agla-doc-tools` のセットアップ (lint ツール導入) | REQ-F-005                       |
+| lint-execute         | 削除済み除外 + textlint / markdownlint 実行       | REQ-F-001, REQ-F-002, REQ-F-006 |
+
+#### Unit Interaction Map
+
+```text
+[trigger: push / pull_request / workflow_dispatch]
+        |
+        v
++---------------------------+
+| actions/checkout          |
+| (fetch-depth: 0)          |
++---------------------------+
+        |
+        v
++---------------------------+
+| environment-validate      |
+| (ca-validate-environment) |
+| actions-type: read        |
++---------------------------+
+        |
+        v
++---------------------------+
+| SHA resolve               |
+|  dispatch + HEAD^1 OK  -> before=HEAD^1, after=HEAD    |
+|  dispatch + HEAD^1 NG  -> warning, skip (exit 0)       |
+|  dispatch + other err  -> error (exit non-zero)        |
+|  push / PR             -> before="", after=""          |
++---------------------------+
+        |
+        v
++---------------------------+
+| changed-files-detect      |
+| (ca-get-changed-files)    |
+| pattern: **/*.md          |
++---------------------------+
+        |
+        | outputs.files (newline-separated)
+        | outputs.count (integer)
+        v
++---------------------------+
+| repo-setup                |
+| (ca-setup-repo)           |
++---------------------------+
+        |
+        | textlint / markdownlint-cli2 available
+        v
++---------------------------+
+| lint-execute              |
+|  count==0 -> skip+warning |
+|  file deleted -> skip     |
+|  else -> run linters      |
++---------------------------+
+        |
+        v
+   [success / failure]
+```
+
+#### Data Flow Diagram
+
+```text
+[GitHub Event]
+      |
+      v
+[actions/checkout fetch-depth:0]
+      |
+      v
+[ca-validate-environment actions-type:read]
+      |
+      v
+[Resolve before-sha / after-sha]
+      |
+      +-- dispatch + HEAD^1 OK  --> before=HEAD^1, after=HEAD
+      +-- dispatch + HEAD^1 NG  --> [warning log, exit 0]
+      +-- dispatch + other err  --> [error log, exit non-zero]
+      +-- push / PR             --> before="", after=""
+      |
+      v
+[ca-get-changed-files pattern:**/*.md]
+      |
+      v
+[outputs.files, outputs.count]
+      |
+      v
+[count == 0?] --yes--> [warning log, exit 0]
+      |
+      no
+      v
+[ca-setup-repo repo:agla-doc-tools]
+      |
+      v
+[for each file in outputs.files]
+      |
+      +--[file deleted?] --yes--> ["deleted -> skip" log, continue]
+      |
+      no
+      v
+[textlint] --fail--> [exit non-zero]
+      |
+      ok
+      v
+[markdownlint-cli2] --fail--> [exit non-zero]
+      |
+      ok
+      v
+[exit 0]
+```
+
+### 2.4 Non-Goals
+
+> **Derivation**: REQUIREMENTS の "Out of Scope" セクションから導出。
+
+- reusable workflow (`ru-*`) の作成
+- 他のワークフローファイルの変更
+- textlint・markdownlint の設定変更
+- lint ルールの追加・変更
+
+### 2.5 Behavioral Design Decisions
+
+| ID    | Decision                                                                                                                           | Rationale                                                                                                | Affected Rules               | Status |
+| ----- | ---------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ---------------------------- | ------ |
+| DD-01 | composite actions を step-level で直接呼び出す (job-level reusable workflow は使わない)                                            | lint ロジックの保守性を高め、共通基盤の恩恵を受けるため (DR-01)                                          | R-002a〜R-002d, R-003, R-004 | Active |
+| DD-02 | workflow_dispatch 時は `git rev-parse HEAD^1` / `HEAD` でSHAを解決し環境変数にセット、他イベントは空文字                           | `github.sha^1` expression は YAML では直接使用できないため                                               | R-002                        | Active |
+| DD-03 | lint は `textlint --config configs/textlintrc.yaml` と `markdownlint-cli2 --config configs/.markdownlint-cli2.yaml` を直接呼び出す | `pnpm run lint:markdown` は `XDG_CONFIG_HOME` に依存するため除外。`run-textlint.sh` ラッパーを経由しない | R-005                        | Active |
+| DD-04 | 削除済みファイルの除外は caller (ワークフロー) 側の責務とする                                                                      | `ca-get-changed-files` の責務範囲を超えないため (DR-04)                                                  | R-005                        | Active |
+| DD-05 | 使用するすべての Action を commit SHA で固定する                                                                                   | サプライチェーンリスク対策 (DR-07)                                                                       | 全ルール                     | Active |
+
+### 2.6 Related Decision Records
+
+| DR-ID | Title                                                        | Phase | Impact on This Spec                               |
+| ----- | ------------------------------------------------------------ | ----- | ------------------------------------------------- |
+| DR-01 | composite actions を直接呼び出す                             | req   | step-level 呼び出し構成を規定 (DD-01 の根拠)      |
+| DR-02 | ca-setup-repo で agla-doc-tools をセットアップする           | req   | repo-setup ユニットの対象リポジトリを確定         |
+| DR-03 | push トリガーは main ブランチのみ対象                        | req   | R-001 のトリガー条件に影響                        |
+| DR-04 | SHA 指定済みの場合は優先使用、未指定時はイベントから自動取得 | req   | changed-files-detect の SHA 解決ロジックを規定    |
+| DR-07 | 使用するすべての Action を commit SHA で固定する             | req   | 全ステップの Action 参照方法を制約 (DD-05 の根拠) |
+
+### 2.7 DD to DR Promotion Criteria
+
+> **Purpose**: DD を正式な DR に昇格させるかどうかの判断基準。昇格はヒューマンジャッジメントによる。
+
+**昇格を検討すべき条件**:
+
+1. 複数の仕様・モジュールをまたぐ影響がある
+2. 将来の設計選択を制約するアーキテクチャ上の決定である
+3. 複数の有力な代替案が存在した
+4. 外部関係者がレビューできるようにすべき決定である
+
+現時点で DD-01〜DD-05 はすべてこの仕様内にローカルな決定であり、対応する DR (DR-01 等) がすでに存在するため昇格不要。
+
+---
+
+## 3. Behavioral Specification
+
+### 3.1 Input Domain
+
+- トリガー: `push` (main ブランチ、`paths: ['**/*.md']`) 、`pull_request` (main ブランチ、`paths: ['**/*.md']`) 、`workflow_dispatch`
+- ステップ実行順序 (この順序で実行しなければならない。順序の変更は禁止する):
+  1. `actions/checkout` (fetch-depth: 0)
+  2. `ca-validate-environment` (actions-type: read)
+  3. SHA 解決 (トリガー種別に応じて before-sha / after-sha を決定)
+  4. `ca-get-changed-files` (pattern: `**/*.md`)
+  5. `ca-setup-repo` (repo: `aglabo/agla-doc-tools`、ref: commit SHA 固定)
+  6. lint 実行
+- 前提条件:
+  - `actions/checkout` は `fetch-depth: 0` で実行しなければならない (MUST) 。`fetch-depth: 1` またはデフォルト値を使用してはならない
+  - `ca-validate-environment` は `actions/checkout` の直後、他のいかなるステップより前に実行しなければならない (MUST)
+  - `ca-setup-repo` の `ref` は commit SHA で固定しなければならない (MUST) 。ブランチ名・可変タグの使用は禁止する
+  - すべての Action が commit SHA で固定されていること
+
+### 3.2 Output Semantics
+
+- 成功 (exit 0):
+  - lint エラーなし
+  - 変更ファイルが 0 件 (スキップ + warning ログ)
+- 失敗 (exit non-zero):
+  - textlint または markdownlint がエラーを検出
+  - `ca-validate-environment` が環境検証に失敗
+  - `ca-get-changed-files` が SHA 解決に失敗
+
+---
+
+## 4. Decision Rules
+
+<!--
+Rule ID format: R-NNN (sequential, stable)
+Rule IDs are referenced in Traceability and Edge Cases.
+-->
+
+評価はこの順序で実行しなければならない。順序の変更は禁止する。
+
+### R-001: トリガー条件評価
+
+| Rule ID | Step | Condition                                                              | Outcome                 |
+| ------- | ---: | ---------------------------------------------------------------------- | ----------------------- |
+| R-001a  |    1 | `push` イベント、かつ対象ブランチが `main`、かつ `*.md` を含む         | lint ジョブを起動する   |
+| R-001b  |    2 | `pull_request` イベント、かつ対象ブランチが `main`、かつ `*.md` を含む | lint ジョブを起動する   |
+| R-001c  |    3 | `workflow_dispatch` イベント                                           | lint ジョブを起動する   |
+| R-001d  |    4 | 上記以外 (`*.md` を含まない push / PR など)                            | lint ジョブは起動しない |
+
+### R-002: SHA 解決ルール
+
+| Rule ID | Step | Condition                                                                          | Outcome                                                                     |
+| ------- | ---: | ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| R-002a  |    1 | `workflow_dispatch` イベント、かつ `git rev-parse HEAD^1` が成功する               | `HEAD^1` を before-sha、`HEAD` を after-sha として環境変数にセット          |
+| R-002b  |    2 | `workflow_dispatch` イベント、かつ `HEAD^1` が存在しない (リポジトリの最初の push) | warning ログを出力して lint をスキップし exit 0                             |
+| R-002c  |    3 | `workflow_dispatch` イベント、かつ `git rev-parse` がその他の理由で失敗する        | エラーログを出力してジョブを失敗させる (exit non-zero)                      |
+| R-002d  |    4 | `push` または `pull_request` イベント                                              | before-sha / after-sha を空文字にセット (`ca-get-changed-files` が自動解決) |
+
+### R-003: 環境検証
+
+| Rule ID | Step | Condition                                                   | Outcome                                                                    |
+| ------- | ---: | ----------------------------------------------------------- | -------------------------------------------------------------------------- |
+| R-003   |    1 | `actions/checkout` の直後、かつ他のいかなるステップより前に | `ca-validate-environment` を実行する。失敗した場合はジョブを即時失敗させる |
+
+### R-004: 変更ファイル取得
+
+| Rule ID | Step | Condition                                      | Outcome                                                                               |
+| ------- | ---: | ---------------------------------------------- | ------------------------------------------------------------------------------------- |
+| R-004a  |    1 | R-002 で解決した before-sha / after-sha を使用 | `ca-get-changed-files` に `pattern: '**/*.md'` を渡して実行する                       |
+| R-004b  |    2 | `ca-get-changed-files` 正常完了                | `outputs.files` (改行区切りパス) と `outputs.count` (整数) が確定する                 |
+| R-004c  |    3 | before-sha がオールゼロ (初回 push)            | `ca-get-changed-files` が自動的に空ツリー SHA にフォールバック。caller 側の処理は不要 |
+
+### R-005: lint 実行
+
+| Rule ID | Step | Condition                                   | Outcome                                                                             |
+| ------- | ---: | ------------------------------------------- | ----------------------------------------------------------------------------------- |
+| R-005a  |    1 | `outputs.count` が 0                        | lint ステップをスキップし、warning メッセージをログに出力して exit 0                |
+| R-005b  |    2 | `outputs.count` が 1 以上                   | `outputs.files` の各ファイルに対して R-005c〜R-005f を適用する                      |
+| R-005c  |    3 | ファイルがファイルシステム上に存在しない    | "deleted → skip" をログに出力してそのファイルをスキップする                         |
+| R-005d  |    4 | ファイルが存在する                          | textlint ツールをファイルに対して実行する                                           |
+| R-005e  |    5 | R-005d が成功 (exit 0)                      | markdownlint ツールをリポジトリ内設定ファイルを使用してファイルに対して実行する     |
+| R-005f  |    6 | textlint または markdownlint が非ゼロで終了 | 後続の lint ステップ (markdownlint 等) を実行せずジョブを即時失敗させる (fail-fast) |
+
+<!-- impl-note: R-005d は `textlint --config configs/textlintrc.yaml $FILES` で一括実行する -->
+<!-- impl-note: R-005e は `markdownlint-cli2 --config configs/.markdownlint-cli2.yaml $FILES` で一括実行する -->
+<!-- impl-note: R-005b の outputs.files は改行区切りを削除済みファイル除外後にスペース区切りに変換して $FILES として lint ツールに一括渡しする -->
+<!-- impl-note: fail-fast のため textlint が失敗した時点で後続の lint ステップ (markdownlint) は実行しない -->
+
+---
+
+## 5. Edge Cases
+
+| Input / Condition                                         | 振る舞い                                                     | REQ           | Rationale                                                |
+| --------------------------------------------------------- | ------------------------------------------------------------ | ------------- | -------------------------------------------------------- |
+| 初回 push (before-sha がオールゼロ)                       | `ca-get-changed-files` が空ツリーとの diff にフォールバック  | REQ-F-004     | caller 側処理不要。リポジトリ全ファイルが対象になる      |
+| `outputs.count` が 0                                      | lint をスキップし warning ログを出力して exit 0              | REQ-F-006     | 変更ファイルなし = lint 不要。エラーにしない             |
+| 変更ファイルに削除済みファイルが含まれる                  | 存在チェックで除外し "deleted → skip" をログに出力           | REQ-F-006     | 存在しないファイルを lint ツールに渡すとエラーになるため |
+| `*.md` 以外の変更のみを含む push / PR                     | lint ジョブ自体が起動しない (paths フィルター)               | REQ-F-001/002 | GitHub Actions の `paths` フィルターで制御               |
+| workflow_dispatch で main ブランチ以外から実行            | lint ジョブは起動する (workflow_dispatch は branch 制約なし) | REQ-F-007     | 手動実行はどのブランチからでも可能                       |
+| workflow_dispatch で HEAD^1 が存在しない (最初のコミット) | warning ログを出力して lint をスキップし exit 0              | REQ-F-007     | 比較対象がないため lint 不要。エラーにしない             |
+| 変更ファイルがすべて削除済み (count > 0 だが全件スキップ) | 全ファイルを "deleted → skip" でスキップし exit 0            | REQ-F-006     | lint 対象ファイルが残らない = lint 不要。エラーにしない  |
+| textlint はエラーあり                                     | textlint 失敗で即終了 (後続の lint ステップを実行しない)     | REQ-F-006     | fail-fast はツール単位。エラー詳細はローカルで確認       |
+
+---
+
+## 6. Requirements Traceability
+
+| Requirement ID | Spec Rule(s)                   | Notes                                                        |
+| -------------- | ------------------------------ | ------------------------------------------------------------ |
+| REQ-F-001      | R-001a, R-005d, R-005e         | push トリガー + lint 実行                                    |
+| REQ-F-002      | R-001b, R-005d, R-005e         | pull_request トリガー + lint 実行                            |
+| REQ-F-003      | R-003                          | ca-validate-environment を最初のステップで実行               |
+| REQ-F-004      | R-002, R-004                   | SHA 解決 + ca-get-changed-files 実行                         |
+| REQ-F-005      | Section 2.2 Assumptions        | ca-setup-repo による agla-doc-tools セットアップ             |
+| REQ-F-006      | R-005a〜R-005f                 | count==0 スキップ、削除済みスキップ、lint 実行               |
+| REQ-F-007      | R-001c, R-002a, R-002b, R-002c | workflow_dispatch トリガー + SHA 解決 (スキップ・エラー含む) |
+| REQ-NF-001     | Section 2.1                    | composite actions 呼び出し中心の構成                         |
+| REQ-NF-002     | Section 2.2 Assumptions        | 外部リポジトリからの composite actions 参照                  |
+| REQ-C-001      | Section 3.1 前提条件           | fetch-depth: 0 は checkout の前提条件                        |
+| REQ-C-002      | R-001a                         | push トリガーは main ブランチのみ                            |
+| REQ-C-003      | R-001a, R-001b                 | paths フィルター `**/*.md`                                   |
+| REQ-C-004      | Section 3.1 Input Domain       | 全 Action を commit SHA で固定                               |
+| REQ-C-005      | Section 7 Open Questions       | ca-get-changed-files の SHA 優先動作を先に実装要             |
+
+---
+
+## 7. Open Questions
+
+> **Status**: INCOMPLETE (REQ-C-005 の前提条件が未解決)
+
+| # | Question                                                                                        | Source    | Impact                                                                      |
+| - | ----------------------------------------------------------------------------------------------- | --------- | --------------------------------------------------------------------------- |
+| 1 | `ca-get-changed-files` の SHA 指定優先動作 (DR-04) が `aglabo/ci-platform` に実装済みか         | REQ-C-005 | 未実装の場合、`ci-lint-articles.yaml` の実装前に ci-platform 側の対応が必要 |
+| 2 | `ca-validate-environment`、`ca-get-changed-files`、`ca-setup-repo` の step-level 呼び出し用 SHA | REQ-C-004 | 実装時に各 composite action の最新 commit SHA を確定する必要がある          |
+
+---
+
+## 8. Change History
+
+| Date       | Version | Description                                                                                                                                                                                                  |
+| ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 2026-06-22 | 1.0.0   | Initial specification                                                                                                                                                                                        |
+| 2026-06-22 | 1.0.1   | Codex review 対応: HEAD^1 なし時の warning スキップ追加 (R-002b) 、fail-fast 明記 (R-005e/f) 、パス展開安全性を Assumptions に追記                                                                           |
+| 2026-06-22 | 1.0.2   | explore review 対応: ステップ実行順序を Section 3.1 に明記、R-002c (git rev-parse その他エラー → exit non-zero) 追加、図を更新、REQ-F-007 トレーサビリティに R-002b/c 追記                                   |
+| 2026-06-22 | 1.0.3   | harden review 対応: ca-setup-tool → ca-setup-repo に統一、ステップ順序 MUST 化、fetch-depth MUST 追記、ca-setup-repo の ref commit SHA 固定 MUST 追記、R-005f を「後続の lint ステップを実行しない」に明確化 |
+| 2026-06-22 | 1.0.4   | fix review 対応: フロントマター version 修正、DD-01 Affected Rules 修正、R-003 条件文を Section 3.1 に統一、REQ-C-001 参照修正、R-005b 参照範囲を R-005c〜R-005f に修正                                      |
+| 2026-06-22 | 1.0.5   | Codex review 対応: ファイルパス特殊文字制約を Assumptions に追記、fail-fast をツール単位と明記、全削除済みシナリオを Edge Cases に追加                                                                       |

--- a/docs/.deckrd/workflows/lint-article/tasks/tasks.md
+++ b/docs/.deckrd/workflows/lint-article/tasks/tasks.md
@@ -1,0 +1,231 @@
+---
+title: "Implementation Tasks: ci-lint-articles Composite Action Migration"
+module: "workflows/lint-article"
+status: Active
+created: "2026-06-23"
+source: specifications.md
+---
+
+<!-- textlint-disable
+  ja-technical-writing/sentence-length
+  -->
+<!-- markdownlint-disable no-duplicate-heading -->
+
+## Task Summary
+
+| Test Target            | Scenarios | Cases | Status      |
+| ---------------------- | --------- | ----- | ----------- |
+| T-01: トリガー条件     | 3         | 4     | in progress |
+| T-02: SHA 解決         | 3         | 4     | in progress |
+| T-03: 変更ファイル取得 | 2         | 5     | in progress |
+| T-04: lint 実行        | 4         | 8     | in progress |
+
+---
+
+## T-01: トリガー条件 (R-001)
+
+### [正常] Normal Cases
+
+#### T-01-01: push トリガー起動
+
+- [ ] **T-01-01-01**: main ブランチへの *.md push で lint ジョブが起動する
+  - Target: `ci-lint-articles.yaml` の `on.push` 定義
+  - Scenario: Given main ブランチに `*.md` を含む push がある、When GitHub Actions の push イベントが発火する
+  - Expected: Then YAML に `on.push.branches: [main]` かつ `on.push.paths: ['**/*.md']` が定義されていなければならない (MUST)
+
+- [ ] **T-01-01-02**: main ブランチへの非 Markdown push で lint ジョブが起動しない
+  - Target: `ci-lint-articles.yaml` の `on.push.paths` フィルター
+  - Scenario: Given main ブランチに `*.md` を含まない push がある、When GitHub Actions の push イベントが発火する
+  - Expected: Then `on.push.paths: ['**/*.md']` フィルターが定義されており、非 Markdown push ではジョブが起動しないこと (MUST)
+
+#### T-01-02: pull_request トリガー起動
+
+- [ ] **T-01-02-01**: main 向け PR に *.md 変更があれば lint ジョブが起動する
+  - Target: `ci-lint-articles.yaml` の `on.pull_request` 定義
+  - Scenario: Given main ブランチへの pull_request に `*.md` 変更が含まれる、When pull_request イベントが発火する
+  - Expected: Then YAML に `on.pull_request.branches: [main]` かつ `on.pull_request.paths: ['**/*.md']` が定義されていなければならない (MUST)
+
+#### T-01-03: workflow_dispatch トリガー起動
+
+- [ ] **T-01-03-01**: workflow_dispatch で lint ジョブが起動する
+  - Target: `ci-lint-articles.yaml` の `on.workflow_dispatch` 定義
+  - Scenario: Given 任意のブランチから手動実行する、When `workflow_dispatch` イベントが発火する
+  - Expected: Then YAML に `on.workflow_dispatch:` が定義されていなければならない (MUST)
+
+---
+
+## T-02: SHA 解決 (R-002)
+
+### [正常] Normal Cases
+
+#### T-02-01: workflow_dispatch で親コミットあり
+
+- [ ] **T-02-01-01**: workflow_dispatch で HEAD^1 が取得でき GITHUB_ENV に書き込まれる
+  - Target: `resolve-sha` ステップのシェルスクリプト
+  - Scenario: Given `workflow_dispatch` イベント、かつ `git rev-list --parents -n 1 HEAD` が 2 フィールド以上を返す (親あり)
+  - Expected: Then `BEFORE_SHA=<HEAD^1>`, `AFTER_SHA=<HEAD>` が `GITHUB_ENV` に書き込まれ、
+    `skip=false` が `GITHUB_OUTPUT` に書き込まれなければならない (MUST) 。
+    また `changed-files` ステップの `with.before-sha: ${{ env.BEFORE_SHA }}` / `with.after-sha: ${{ env.AFTER_SHA }}` が
+    YAML に定義されていなければならない (MUST)
+
+#### T-02-02: push / pull_request では空文字 SHA を設定
+
+- [ ] **T-02-02-01**: push / PR 時は BEFORE_SHA / AFTER_SHA が空文字で GITHUB_ENV に書き込まれる
+  - Target: `resolve-sha` ステップのシェルスクリプト
+  - Scenario: Given `push` または `pull_request` イベント
+  - Expected: Then `BEFORE_SHA=""`, `AFTER_SHA=""` が `GITHUB_ENV` に書き込まれ、`skip=false` が `GITHUB_OUTPUT` に書き込まれなければならない (MUST)
+
+### [異常] Error Cases
+
+#### T-02-03: workflow_dispatch で git コマンド失敗
+
+- [ ] **T-02-03-01**: git rev-list がその他エラーで失敗した場合、ジョブが失敗する
+  - Target: `resolve-sha` ステップのシェルスクリプト
+  - Scenario: Given `workflow_dispatch` イベント、かつ `git rev-list` が非ゼロ終了する
+  - Expected: Then ジョブが exit non-zero で失敗する
+
+### [エッジケース] Edge Cases
+
+#### T-02-04: workflow_dispatch で初回コミット (親なし)
+
+- [ ] **T-02-04-01**: 初回コミット (parent 数 == 0) の場合、warning を出力して後続ステップをスキップする
+  - Target: `resolve-sha` ステップのシェルスクリプト
+  - Scenario: Given `workflow_dispatch` イベント、かつ `git rev-list --parents -n 1 HEAD` が 1 フィールド (親なし) を返す
+  - Expected: Then `skip=true` が `GITHUB_OUTPUT` に書き込まれ、warning ログが出力され、exit 0 となる。
+    後続の `changed-files` / `setup-repo` / `lint` ステップは `if: steps.resolve-sha.outputs.skip != 'true'` により実行されない
+
+---
+
+## T-03: 変更ファイル取得 (R-003 / R-004)
+
+### [正常] Normal Cases
+
+#### T-03-01: 環境検証ステップの配置順序
+
+- [ ] **T-03-01-01**: `ca-validate-environment` が `checkout` の直後・他ステップより前に配置されている
+  - Target: `ci-lint-articles.yaml` のステップ順序
+  - Scenario: Given ワークフローが起動する、When ステップ定義を確認する
+  - Expected: Then `validate-env` ステップが YAML のステップリスト上で `checkout` の直後 (2 番目) に定義されていなければならない (MUST) 。
+    `resolve-sha` より前に配置されていること。また `checkout` の `fetch-depth: 0` が定義されていなければならない (MUST)
+
+#### T-03-02: ca-get-changed-files で変更 *.md を取得
+
+- [ ] **T-03-02-01**: changed-files ステップが BEFORE_SHA / AFTER_SHA を渡して実行される
+  - Target: `changed-files` ステップの with パラメータ
+  - Scenario: Given `resolve-sha` が完了し `GITHUB_ENV` に SHA が設定済み、When `changed-files` ステップが実行される
+  - Expected: Then `ca-get-changed-files` に `pattern: '**/*.md'`、`before-sha: ${{ env.BEFORE_SHA }}`、
+    `after-sha: ${{ env.AFTER_SHA }}` が渡されなければならない (MUST)
+
+- [ ] **T-03-02-02**: skip=true の場合、changed-files ステップが実行されない
+  - Target: `changed-files` ステップの `if:` 条件
+  - Scenario: Given `resolve-sha` が `skip=true` を出力した、When `changed-files` ステップが評価される
+  - Expected: Then `if: steps.resolve-sha.outputs.skip != 'true'` 条件が YAML の `changed-files` ステップに定義されており、
+    `skip=true` 時にステップが実行されないこと (MUST)
+
+#### T-03-02-03: ca-get-changed-files が失敗した場合、ジョブが失敗する
+
+- [ ] **T-03-02-03**: `ca-get-changed-files` が非ゼロで終了した場合、ジョブが即時失敗する
+  - Target: `changed-files` ステップ（composite action の失敗伝播）
+  - Scenario: Given `ca-get-changed-files` が内部エラー等で非ゼロ終了する
+  - Expected: Then GitHub Actions のデフォルト動作（`continue-on-error: false`）によりジョブが即時失敗する。
+    `continue-on-error: true` が設定されていないこと (MUST)
+
+### [エッジケース] Edge Cases
+
+#### T-03-03: before-sha オールゼロ (初回 push)
+
+- [ ] **T-03-03-01**: before-sha がオールゼロの場合、ca-get-changed-files が空ツリーとの差分にフォールバックする
+  - Target: `ca-get-changed-files` の動作 (自作 composite action の契約)
+  - Scenario: Given push イベント、かつ before-sha がオールゼロ (新規リポジトリへの最初の push)
+  - Expected: Then `ca-get-changed-files` が自動的に空ツリー SHA にフォールバックし、リポジトリ全 `*.md` ファイルが `outputs.files` に含まれる
+
+---
+
+## T-04: lint 実行 (R-005)
+
+### [正常] Normal Cases
+
+#### T-04-00: ファイルリスト変換
+
+- [ ] **T-04-00-01**: 改行区切りの outputs.files をスペース区切りに変換して lint ツールに一括渡しする
+  - Target: `lint` ステップのシェルスクリプト（変換ロジック）
+  - Scenario: Given `CHANGED_FILES` に改行区切りのファイルパスリストが格納されている
+  - Expected: Then `printf '%s\n' "$CHANGED_FILES" | tr '\n' ' '` 等で変換し、
+    削除済みファイルを除外したスペース区切りファイルリストを構築した上で、`textlint --config configs/textlintrc.yaml $FILES`
+    および `markdownlint-cli2 --config configs/.markdownlint-cli2.yaml $FILES` に一括渡しすること (MUST)
+
+#### T-04-01: 変更ファイルが存在する場合の lint 実行
+
+- [ ] **T-04-01-01**: 存在するファイルに textlint が一括実行される
+  - Target: `lint` ステップのシェルスクリプト (R-005d)
+  - Scenario: Given `outputs.count` が 1 以上で、対象ファイルがファイルシステム上に存在する
+  - Expected: Then T-04-00-01 で構築したスペース区切りファイルリストを引数として `textlint --config configs/textlintrc.yaml $FILES` が
+    シェルスクリプト内に定義されていなければならない (MUST)
+
+- [ ] **T-04-01-02**: textlint 成功後に markdownlint が一括実行される
+  - Target: `lint` ステップのシェルスクリプト (R-005e)
+  - Scenario: Given textlint が exit 0 で完了した
+  - Expected: Then T-04-00-01 で構築したスペース区切りファイルリストを引数として
+    `markdownlint --config configs/.markdownlint-cli2.yaml $FILES` がシェルスクリプト内に定義されていなければならない (MUST)
+
+### [異常] Error Cases
+
+#### T-04-02: lint エラーで即時失敗 (fail-fast)
+
+- [ ] **T-04-02-01**: textlint が非ゼロで終了した場合、markdownlint を実行せずジョブが失敗する
+  - Target: `lint` ステップのシェルスクリプト (R-005f)
+  - Scenario: Given `textlint --config configs/textlintrc.yaml "$file"` が非ゼロで終了する
+  - Expected: Then `bash -eo pipefail` で textlint が非ゼロ終了した時点でシェルスクリプトが停止し、`markdownlint` の呼び出し行に到達しないこと (MUST) 。
+    ジョブが exit non-zero で終了しなければならない (MUST)
+
+- [ ] **T-04-02-02**: CHANGED_COUNT が非数値の場合、ジョブが失敗する
+  - Target: `lint` ステップの CHANGED_COUNT 数値検証
+  - Scenario: Given `steps.changed-files.outputs.count` が空または数値以外の文字列
+  - Expected: Then `[[ "$CHANGED_COUNT" =~ ^[0-9]+$ ]]` の検証が失敗し、ジョブが exit non-zero で終了する
+
+### [エッジケース] Edge Cases
+
+#### T-04-03: スキップシナリオ
+
+- [ ] **T-04-03-01**: outputs.count が 0 の場合、lint をスキップして warning を出力し exit 0 になる
+  - Target: `lint` ステップのシェルスクリプト (R-005a)
+  - Scenario: Given `CHANGED_COUNT` が `"0"`
+  - Expected: Then warning メッセージがログに出力され、lint を実行せず exit 0 で完了する
+
+- [ ] **T-04-03-02**: 削除済みファイルを "deleted -> skip" でスキップする
+  - Target: `lint` ステップのシェルスクリプト (R-005c)
+  - Scenario: Given `outputs.files` に含まれるファイルがファイルシステム上に存在しない (削除済み)
+  - Expected: Then `"deleted -> skip"` がログに出力され、そのファイルへの lint は実行されず次のファイルに進む (exit 0)
+
+- [ ] **T-04-03-03**: 全ファイルが削除済みの場合でも exit 0 になる
+  - Target: `lint` ステップのシェルスクリプト (R-005b / R-005c)
+  - Scenario: Given `CHANGED_COUNT` が 1 以上、かつ `outputs.files` に含まれる全ファイルがファイルシステム上に存在しない
+  - Expected: Then 全ファイルが `"deleted -> skip"` でスキップされ、lint を一切実行せず exit 0 で完了する
+
+---
+
+## Traceability
+
+| Task ID    | Spec Rule      | Requirement |
+| ---------- | -------------- | ----------- |
+| T-01-01-01 | R-001a         | REQ-F-001   |
+| T-01-01-02 | R-001d         | REQ-C-003   |
+| T-01-02-01 | R-001b         | REQ-F-002   |
+| T-01-03-01 | R-001c         | REQ-F-007   |
+| T-02-01-01 | R-002a         | REQ-F-004   |
+| T-02-02-01 | R-002d         | REQ-F-004   |
+| T-02-03-01 | R-002c         | REQ-F-007   |
+| T-02-04-01 | R-002b         | REQ-F-007   |
+| T-03-01-01 | R-003          | REQ-F-003   |
+| T-03-02-01 | R-004a, R-004b | REQ-F-004   |
+| T-03-02-02 | R-002b (skip)  | REQ-F-007   |
+| T-03-02-03 | R-004a         | REQ-F-004   |
+| T-03-03-01 | R-004c         | REQ-F-004   |
+| T-04-00-01 | R-005b         | REQ-F-006   |
+| T-04-01-01 | R-004b, R-005d | REQ-F-006   |
+| T-04-01-02 | R-004b, R-005e | REQ-F-006   |
+| T-04-02-01 | R-005f         | REQ-F-006   |
+| T-04-02-02 | R-005b (guard) | REQ-F-006   |
+| T-04-03-01 | R-005a         | REQ-F-006   |
+| T-04-03-02 | R-005c         | REQ-F-006   |
+| T-04-03-03 | R-005b, R-005c | REQ-F-006   |

--- a/docs/.deckrd/workflows/lint-article/tasks/tasks.md
+++ b/docs/.deckrd/workflows/lint-article/tasks/tasks.md
@@ -9,16 +9,62 @@ source: specifications.md
 <!-- textlint-disable
   ja-technical-writing/sentence-length
   -->
-<!-- markdownlint-disable no-duplicate-heading -->
+<!-- markdownlint-disable no-duplicate-heading line-length -->
 
 ## Task Summary
 
-| Test Target            | Scenarios | Cases | Status      |
-| ---------------------- | --------- | ----- | ----------- |
-| T-01: トリガー条件     | 3         | 4     | in progress |
-| T-02: SHA 解決         | 3         | 4     | in progress |
-| T-03: 変更ファイル取得 | 2         | 5     | in progress |
-| T-04: lint 実行        | 4         | 8     | in progress |
+| Test Target                   | Scenarios | Cases | Status      |
+| ----------------------------- | --------- | ----- | ----------- |
+| T-00: YAML 構造・セキュリティ | 2         | 8     | done        |
+| T-01: トリガー条件            | 3         | 4     | done        |
+| T-02: SHA 解決                | 3         | 4     | done        |
+| T-03: 変更ファイル取得        | 4         | 7     | done        |
+| T-04: lint 実行               | 4         | 8     | done        |
+
+---
+
+## T-00: YAML 構造・セキュリティ (DD-05 / REQ-C-004 / R-003)
+
+### [正常] Normal Cases
+
+#### T-00-01: ワークフロー全体の YAML 構造
+
+- [x] **T-00-01-01**: 6 ステップが定義された順序で配置されている
+  - Target: `ci-lint-articles.yaml` のステップリスト
+  - Scenario: Given ワークフローが定義されている、When ステップ定義を確認する
+  - Expected: Then checkout → validate-env → resolve-sha → changed-files → setup-repo → lint の順に 6 ステップが配置されていなければならない (MUST)
+
+- [x] **T-00-01-02**: checkout に `persist-credentials: false` が設定されている
+  - Target: `ci-lint-articles.yaml` の `checkout` ステップ
+  - Scenario: Given checkout ステップが定義されている
+  - Expected: Then `with.persist-credentials: false` が設定されていなければならない (MUST)
+
+- [x] **T-00-01-03**: skip 伝播の `if` 条件が changed-files / setup-repo / lint の 3 ステップに付与されている
+  - Target: `ci-lint-articles.yaml` の changed-files / setup-repo / lint 各ステップ
+  - Scenario: Given resolve-sha ステップが `skip=true` を出力した
+  - Expected: Then 3 ステップそれぞれに `if: steps.resolve-sha.outputs.skip != 'true'` が定義されていなければならない (MUST)
+
+#### T-00-02: 全 Action の commit SHA ピン留め (DD-05)
+
+- [x] **T-00-02-01**: `actions/checkout` が commit SHA で固定されている
+  - Target: `ci-lint-articles.yaml` の checkout ステップ
+  - Expected: Then `uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3` が定義されていなければならない (MUST)
+
+- [x] **T-00-02-02**: `ca-validate-environment` が commit SHA で固定されている
+  - Target: `ci-lint-articles.yaml` の validate-env ステップ
+  - Expected: Then `uses: aglabo/ci-platform/.github/actions/ca-validate-environment@f4e8d971ee9093901df0255154e643fd1f2ee10d` が定義されていなければならない (MUST)
+
+- [x] **T-00-02-03**: `ca-get-changed-files` が commit SHA で固定されている
+  - Target: `ci-lint-articles.yaml` の changed-files ステップ
+  - Expected: Then `uses: aglabo/ci-platform/.github/actions/ca-get-changed-files@f4e8d971ee9093901df0255154e643fd1f2ee10d` が定義されていなければならない (MUST)
+
+- [x] **T-00-02-04**: `ca-setup-repo` が commit SHA で固定されている
+  - Target: `ci-lint-articles.yaml` の setup-repo ステップ
+  - Expected: Then `uses: aglabo/ci-platform/.github/actions/ca-setup-repo@f4e8d971ee9093901df0255154e643fd1f2ee10d` が定義されていなければならない (MUST)
+
+- [x] **T-00-02-05**: `agla-doc-tools` の `ref` が commit SHA で固定されている
+  - Target: `ci-lint-articles.yaml` の setup-repo ステップ `with.ref`
+  - Expected: Then `ref: bec772fc1d22fbf43fd57ef3a71f7972b83b3e24 # v0.1.1` が定義されていなければならない (MUST)
 
 ---
 
@@ -28,26 +74,26 @@ source: specifications.md
 
 #### T-01-01: push トリガー起動
 
-- [ ] **T-01-01-01**: main ブランチへの *.md push で lint ジョブが起動する
+- [x] **T-01-01-01**: main ブランチへの *.md push で lint ジョブが起動する
   - Target: `ci-lint-articles.yaml` の `on.push` 定義
   - Scenario: Given main ブランチに `*.md` を含む push がある、When GitHub Actions の push イベントが発火する
   - Expected: Then YAML に `on.push.branches: [main]` かつ `on.push.paths: ['**/*.md']` が定義されていなければならない (MUST)
 
-- [ ] **T-01-01-02**: main ブランチへの非 Markdown push で lint ジョブが起動しない
+- [x] **T-01-01-02**: main ブランチへの非 Markdown push で lint ジョブが起動しない
   - Target: `ci-lint-articles.yaml` の `on.push.paths` フィルター
   - Scenario: Given main ブランチに `*.md` を含まない push がある、When GitHub Actions の push イベントが発火する
   - Expected: Then `on.push.paths: ['**/*.md']` フィルターが定義されており、非 Markdown push ではジョブが起動しないこと (MUST)
 
 #### T-01-02: pull_request トリガー起動
 
-- [ ] **T-01-02-01**: main 向け PR に *.md 変更があれば lint ジョブが起動する
+- [x] **T-01-02-01**: main 向け PR に *.md 変更があれば lint ジョブが起動する
   - Target: `ci-lint-articles.yaml` の `on.pull_request` 定義
   - Scenario: Given main ブランチへの pull_request に `*.md` 変更が含まれる、When pull_request イベントが発火する
   - Expected: Then YAML に `on.pull_request.branches: [main]` かつ `on.pull_request.paths: ['**/*.md']` が定義されていなければならない (MUST)
 
 #### T-01-03: workflow_dispatch トリガー起動
 
-- [ ] **T-01-03-01**: workflow_dispatch で lint ジョブが起動する
+- [x] **T-01-03-01**: workflow_dispatch で lint ジョブが起動する
   - Target: `ci-lint-articles.yaml` の `on.workflow_dispatch` 定義
   - Scenario: Given 任意のブランチから手動実行する、When `workflow_dispatch` イベントが発火する
   - Expected: Then YAML に `on.workflow_dispatch:` が定義されていなければならない (MUST)
@@ -60,7 +106,7 @@ source: specifications.md
 
 #### T-02-01: workflow_dispatch で親コミットあり
 
-- [ ] **T-02-01-01**: workflow_dispatch で HEAD^1 が取得でき GITHUB_ENV に書き込まれる
+- [x] **T-02-01-01**: workflow_dispatch で HEAD^1 が取得でき GITHUB_ENV に書き込まれる
   - Target: `resolve-sha` ステップのシェルスクリプト
   - Scenario: Given `workflow_dispatch` イベント、かつ `git rev-list --parents -n 1 HEAD` が 2 フィールド以上を返す (親あり)
   - Expected: Then `BEFORE_SHA=<HEAD^1>`, `AFTER_SHA=<HEAD>` が `GITHUB_ENV` に書き込まれ、
@@ -70,7 +116,7 @@ source: specifications.md
 
 #### T-02-02: push / pull_request では空文字 SHA を設定
 
-- [ ] **T-02-02-01**: push / PR 時は BEFORE_SHA / AFTER_SHA が空文字で GITHUB_ENV に書き込まれる
+- [x] **T-02-02-01**: push / PR 時は BEFORE_SHA / AFTER_SHA が空文字で GITHUB_ENV に書き込まれる
   - Target: `resolve-sha` ステップのシェルスクリプト
   - Scenario: Given `push` または `pull_request` イベント
   - Expected: Then `BEFORE_SHA=""`, `AFTER_SHA=""` が `GITHUB_ENV` に書き込まれ、`skip=false` が `GITHUB_OUTPUT` に書き込まれなければならない (MUST)
@@ -79,7 +125,7 @@ source: specifications.md
 
 #### T-02-03: workflow_dispatch で git コマンド失敗
 
-- [ ] **T-02-03-01**: git rev-list がその他エラーで失敗した場合、ジョブが失敗する
+- [x] **T-02-03-01**: git rev-list がその他エラーで失敗した場合、ジョブが失敗する
   - Target: `resolve-sha` ステップのシェルスクリプト
   - Scenario: Given `workflow_dispatch` イベント、かつ `git rev-list` が非ゼロ終了する
   - Expected: Then ジョブが exit non-zero で失敗する
@@ -88,7 +134,7 @@ source: specifications.md
 
 #### T-02-04: workflow_dispatch で初回コミット (親なし)
 
-- [ ] **T-02-04-01**: 初回コミット (parent 数 == 0) の場合、warning を出力して後続ステップをスキップする
+- [x] **T-02-04-01**: 初回コミット (parent 数 == 0) の場合、warning を出力して後続ステップをスキップする
   - Target: `resolve-sha` ステップのシェルスクリプト
   - Scenario: Given `workflow_dispatch` イベント、かつ `git rev-list --parents -n 1 HEAD` が 1 フィールド (親なし) を返す
   - Expected: Then `skip=true` が `GITHUB_OUTPUT` に書き込まれ、warning ログが出力され、exit 0 となる。
@@ -102,7 +148,7 @@ source: specifications.md
 
 #### T-03-01: 環境検証ステップの配置順序
 
-- [ ] **T-03-01-01**: `ca-validate-environment` が `checkout` の直後・他ステップより前に配置されている
+- [x] **T-03-01-01**: `ca-validate-environment` が `checkout` の直後・他ステップより前に配置されている
   - Target: `ci-lint-articles.yaml` のステップ順序
   - Scenario: Given ワークフローが起動する、When ステップ定義を確認する
   - Expected: Then `validate-env` ステップが YAML のステップリスト上で `checkout` の直後 (2 番目) に定義されていなければならない (MUST) 。
@@ -110,13 +156,13 @@ source: specifications.md
 
 #### T-03-02: ca-get-changed-files で変更 *.md を取得
 
-- [ ] **T-03-02-01**: changed-files ステップが BEFORE_SHA / AFTER_SHA を渡して実行される
+- [x] **T-03-02-01**: changed-files ステップが BEFORE_SHA / AFTER_SHA を渡して実行される
   - Target: `changed-files` ステップの with パラメータ
   - Scenario: Given `resolve-sha` が完了し `GITHUB_ENV` に SHA が設定済み、When `changed-files` ステップが実行される
   - Expected: Then `ca-get-changed-files` に `pattern: '**/*.md'`、`before-sha: ${{ env.BEFORE_SHA }}`、
     `after-sha: ${{ env.AFTER_SHA }}` が渡されなければならない (MUST)
 
-- [ ] **T-03-02-02**: skip=true の場合、changed-files ステップが実行されない
+- [x] **T-03-02-02**: skip=true の場合、changed-files ステップが実行されない
   - Target: `changed-files` ステップの `if:` 条件
   - Scenario: Given `resolve-sha` が `skip=true` を出力した、When `changed-files` ステップが評価される
   - Expected: Then `if: steps.resolve-sha.outputs.skip != 'true'` 条件が YAML の `changed-files` ステップに定義されており、
@@ -124,17 +170,29 @@ source: specifications.md
 
 #### T-03-02-03: ca-get-changed-files が失敗した場合、ジョブが失敗する
 
-- [ ] **T-03-02-03**: `ca-get-changed-files` が非ゼロで終了した場合、ジョブが即時失敗する
+- [x] **T-03-02-03**: `ca-get-changed-files` が非ゼロで終了した場合、ジョブが即時失敗する
   - Target: `changed-files` ステップ（composite action の失敗伝播）
   - Scenario: Given `ca-get-changed-files` が内部エラー等で非ゼロ終了する
   - Expected: Then GitHub Actions のデフォルト動作（`continue-on-error: false`）によりジョブが即時失敗する。
     `continue-on-error: true` が設定されていないこと (MUST)
 
+#### T-03-04: ca-setup-repo の設定
+
+- [x] **T-03-04-01**: ca-setup-repo ステップが正しいパラメータで定義されている
+  - Target: `ci-lint-articles.yaml` の `setup-repo` ステップ
+  - Scenario: Given ワークフローが定義されている、When setup-repo ステップ定義を確認する
+  - Expected: Then `repo: aglabo/agla-doc-tools`、`path: .tools/agla-doc-tools`、`ref: bec772fc1d22fbf43fd57ef3a71f7972b83b3e24` が定義されていなければならない (MUST)
+
+- [x] **T-03-04-02**: skip=true の場合、setup-repo ステップが実行されない
+  - Target: `ci-lint-articles.yaml` の `setup-repo` ステップの `if:` 条件
+  - Scenario: Given `resolve-sha` が `skip=true` を出力した
+  - Expected: Then `if: steps.resolve-sha.outputs.skip != 'true'` が定義されており、`skip=true` 時にステップが実行されないこと (MUST)
+
 ### [エッジケース] Edge Cases
 
 #### T-03-03: before-sha オールゼロ (初回 push)
 
-- [ ] **T-03-03-01**: before-sha がオールゼロの場合、ca-get-changed-files が空ツリーとの差分にフォールバックする
+- [x] **T-03-03-01**: before-sha がオールゼロの場合、ca-get-changed-files が空ツリーとの差分にフォールバックする
   - Target: `ca-get-changed-files` の動作 (自作 composite action の契約)
   - Scenario: Given push イベント、かつ before-sha がオールゼロ (新規リポジトリへの最初の push)
   - Expected: Then `ca-get-changed-files` が自動的に空ツリー SHA にフォールバックし、リポジトリ全 `*.md` ファイルが `outputs.files` に含まれる
@@ -147,7 +205,7 @@ source: specifications.md
 
 #### T-04-00: ファイルリスト変換
 
-- [ ] **T-04-00-01**: 改行区切りの outputs.files をスペース区切りに変換して lint ツールに一括渡しする
+- [x] **T-04-00-01**: 改行区切りの outputs.files をスペース区切りに変換して lint ツールに一括渡しする
   - Target: `lint` ステップのシェルスクリプト（変換ロジック）
   - Scenario: Given `CHANGED_FILES` に改行区切りのファイルパスリストが格納されている
   - Expected: Then `printf '%s\n' "$CHANGED_FILES" | tr '\n' ' '` 等で変換し、
@@ -156,13 +214,13 @@ source: specifications.md
 
 #### T-04-01: 変更ファイルが存在する場合の lint 実行
 
-- [ ] **T-04-01-01**: 存在するファイルに textlint が一括実行される
+- [x] **T-04-01-01**: 存在するファイルに textlint が一括実行される
   - Target: `lint` ステップのシェルスクリプト (R-005d)
   - Scenario: Given `outputs.count` が 1 以上で、対象ファイルがファイルシステム上に存在する
   - Expected: Then T-04-00-01 で構築したスペース区切りファイルリストを引数として `textlint --config configs/textlintrc.yaml $FILES` が
     シェルスクリプト内に定義されていなければならない (MUST)
 
-- [ ] **T-04-01-02**: textlint 成功後に markdownlint が一括実行される
+- [x] **T-04-01-02**: textlint 成功後に markdownlint が一括実行される
   - Target: `lint` ステップのシェルスクリプト (R-005e)
   - Scenario: Given textlint が exit 0 で完了した
   - Expected: Then T-04-00-01 で構築したスペース区切りファイルリストを引数として
@@ -172,13 +230,13 @@ source: specifications.md
 
 #### T-04-02: lint エラーで即時失敗 (fail-fast)
 
-- [ ] **T-04-02-01**: textlint が非ゼロで終了した場合、markdownlint を実行せずジョブが失敗する
+- [x] **T-04-02-01**: textlint が非ゼロで終了した場合、markdownlint を実行せずジョブが失敗する
   - Target: `lint` ステップのシェルスクリプト (R-005f)
   - Scenario: Given `textlint --config configs/textlintrc.yaml "$file"` が非ゼロで終了する
   - Expected: Then `bash -eo pipefail` で textlint が非ゼロ終了した時点でシェルスクリプトが停止し、`markdownlint` の呼び出し行に到達しないこと (MUST) 。
     ジョブが exit non-zero で終了しなければならない (MUST)
 
-- [ ] **T-04-02-02**: CHANGED_COUNT が非数値の場合、ジョブが失敗する
+- [x] **T-04-02-02**: CHANGED_COUNT が非数値の場合、ジョブが失敗する
   - Target: `lint` ステップの CHANGED_COUNT 数値検証
   - Scenario: Given `steps.changed-files.outputs.count` が空または数値以外の文字列
   - Expected: Then `[[ "$CHANGED_COUNT" =~ ^[0-9]+$ ]]` の検証が失敗し、ジョブが exit non-zero で終了する
@@ -187,17 +245,17 @@ source: specifications.md
 
 #### T-04-03: スキップシナリオ
 
-- [ ] **T-04-03-01**: outputs.count が 0 の場合、lint をスキップして warning を出力し exit 0 になる
+- [x] **T-04-03-01**: outputs.count が 0 の場合、lint をスキップして warning を出力し exit 0 になる
   - Target: `lint` ステップのシェルスクリプト (R-005a)
   - Scenario: Given `CHANGED_COUNT` が `"0"`
   - Expected: Then warning メッセージがログに出力され、lint を実行せず exit 0 で完了する
 
-- [ ] **T-04-03-02**: 削除済みファイルを "deleted -> skip" でスキップする
+- [x] **T-04-03-02**: 削除済みファイルを "deleted -> skip" でスキップする
   - Target: `lint` ステップのシェルスクリプト (R-005c)
   - Scenario: Given `outputs.files` に含まれるファイルがファイルシステム上に存在しない (削除済み)
   - Expected: Then `"deleted -> skip"` がログに出力され、そのファイルへの lint は実行されず次のファイルに進む (exit 0)
 
-- [ ] **T-04-03-03**: 全ファイルが削除済みの場合でも exit 0 になる
+- [x] **T-04-03-03**: 全ファイルが削除済みの場合でも exit 0 になる
   - Target: `lint` ステップのシェルスクリプト (R-005b / R-005c)
   - Scenario: Given `CHANGED_COUNT` が 1 以上、かつ `outputs.files` に含まれる全ファイルがファイルシステム上に存在しない
   - Expected: Then 全ファイルが `"deleted -> skip"` でスキップされ、lint を一切実行せず exit 0 で完了する
@@ -208,6 +266,14 @@ source: specifications.md
 
 | Task ID    | Spec Rule      | Requirement |
 | ---------- | -------------- | ----------- |
+| T-00-01-01 | R-003, DD-01   | REQ-NF-001  |
+| T-00-01-02 | DD-05          | REQ-C-004   |
+| T-00-01-03 | R-002b (skip)  | REQ-F-007   |
+| T-00-02-01 | DD-05          | REQ-C-004   |
+| T-00-02-02 | DD-05          | REQ-C-004   |
+| T-00-02-03 | DD-05          | REQ-C-004   |
+| T-00-02-04 | DD-05          | REQ-C-004   |
+| T-00-02-05 | DD-05          | REQ-C-004   |
 | T-01-01-01 | R-001a         | REQ-F-001   |
 | T-01-01-02 | R-001d         | REQ-C-003   |
 | T-01-02-01 | R-001b         | REQ-F-002   |
@@ -221,6 +287,8 @@ source: specifications.md
 | T-03-02-02 | R-002b (skip)  | REQ-F-007   |
 | T-03-02-03 | R-004a         | REQ-F-004   |
 | T-03-03-01 | R-004c         | REQ-F-004   |
+| T-03-04-01 | R-004a, R-004b | REQ-F-005   |
+| T-03-04-02 | R-002b (skip)  | REQ-F-007   |
 | T-04-00-01 | R-005b         | REQ-F-006   |
 | T-04-01-01 | R-004b, R-005d | REQ-F-006   |
 | T-04-01-02 | R-004b, R-005e | REQ-F-006   |


### PR DESCRIPTION
## Overview

**Summary**
Migrates `ci-lint-articles.yaml` to use composite actions and adds custom shell scripts with ShellSpec unit tests.

**Background / Motivation**
The previous workflow had tightly-coupled steps for environment validation, changed-file detection, and repo setup. Extracting these into composite actions (`ca-validate-environment`, `ca-get-changed-files`, `ca-setup-repo`) improves reusability. SHA-pinned `uses` references also strengthen supply-chain security.

## Changes

### Core Changes

- `.github/workflows/ci-lint-articles.yaml` — replaced monolithic steps with composite actions; added `push` (main, `*.md`) and `workflow_dispatch` triggers; set `persist-credentials: false`
- `.github/workflows/scripts/resolve-sha.sh` — new script that resolves `BEFORE_SHA` / `AFTER_SHA` for `push`, `pull_request`, and `workflow_dispatch` events
- `.github/workflows/scripts/lint.sh` — new script that validates `CHANGED_COUNT`, excludes deleted files, and runs `textlint` + `markdownlint`

### Test Updates

- `scripts/__tests__/unit/resolve_sha.spec.sh` — ShellSpec tests for resolve-sha.sh (all event types and error cases)
- `scripts/__tests__/unit/lint_sh.spec.sh` — ShellSpec tests for lint.sh (normal, error, and skip behavior)
- `__tests__/unit/ci_lint_articles_yaml.spec.sh` — ShellSpec tests verifying workflow YAML structure and SHA pins

### Removed

- Legacy inline steps for environment setup, file detection, and repo initialization (replaced by composite actions)

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Configuration
- [x] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

- Composite actions are sourced from `aglabo/ci-platform` with SHA-pinned `uses` references.
- `resolve-sha.sh` outputs `skip=true` for `workflow_dispatch` when no parent commit exists, causing subsequent steps to be skipped.
- Deckrd design docs (requirements, specs, tasks, implementation) are stored in `docs/.deckrd/workflows/lint-article/` and are tracked in git.
