### PR TITLE
fix(ci/scripts): resolve BEFORE_SHA from head commit parent

### DIFF
--- a/.github/workflows/scripts/__tests__/unit/resolve_sha.unit.spec.sh
+++ b/.github/workflows/scripts/__tests__/unit/resolve_sha.unit.spec.sh
@@ -23,8 +23,10 @@ Describe 'resolve-sha.sh'
       STUB_DIR=$(mktemp -d)
       export STUB_DIR
 
-      # Stub git to return 2 fields (HEAD SHA + parent SHA)
-      printf '#!/bin/sh\necho "abc123def456 parentsha123"\n' > "$STUB_DIR/git"
+      # Stub git to return multiple lines of "<commit> <parent>" pairs.
+      # Only the first line describes HEAD; later lines are older ancestors and
+      # must never be used for BEFORE_SHA/AFTER_SHA.
+      printf '#!/bin/sh\necho "abc123def456 parentsha123"\necho "parentsha123 grandparent789"\necho "grandparent789 greatgrand000"\n' > "$STUB_DIR/git"
       chmod +x "$STUB_DIR/git"
 
       export PATH="$STUB_DIR:$PATH"

--- a/.github/workflows/scripts/resolve-sha.sh
+++ b/.github/workflows/scripts/resolve-sha.sh
@@ -10,12 +10,15 @@
 set -euo pipefail
 
 if [ "${EVENT_NAME:-}" = "workflow_dispatch" ]; then
-  _parents=$(git rev-list --parents -n 5 HEAD)
-  _field_count=$(echo "$_parents" | wc -w)
+  # "<commit> <parent>..." for HEAD only: field 1 is HEAD, field 2 is its first parent.
+  # An initial commit has no parent, so the line holds a single field.
+  _parents=$(git rev-list --parents -n 1 HEAD)
+  _head_line=$(echo "$_parents" | head -n 1)
+  _field_count=$(echo "$_head_line" | wc -w)
 
   if [ "$_field_count" -ge 2 ]; then
-    _after_sha=$(echo "$_parents"  | head -n 1 | cut -d' ' -f1)
-    _before_sha=$(echo "$_parents" | tail -n 1 | cut -d' ' -f1)
+    _after_sha=$(echo "$_head_line" | cut -d' ' -f1)
+    _before_sha=$(echo "$_head_line" | cut -d' ' -f2)
     echo "BEFORE_SHA=${_before_sha}" >>"${GITHUB_ENV}"
     echo "AFTER_SHA=${_after_sha}" >>"${GITHUB_ENV}"
     echo "skip=false" >>"${GITHUB_OUTPUT}"
@@ -24,7 +27,7 @@ if [ "${EVENT_NAME:-}" = "workflow_dispatch" ]; then
     echo "skip=true" >>"${GITHUB_OUTPUT}"
     exit 0
   fi
-else  # other events: PUSH, PullRequest
+else # other events: PUSH, PullRequest
   echo "BEFORE_SHA=" >>"${GITHUB_ENV}"
   echo "AFTER_SHA=" >>"${GITHUB_ENV}"
   echo "skip=false" >>"${GITHUB_OUTPUT}"

--- a/runners/run-shellspec.sh
+++ b/runners/run-shellspec.sh
@@ -11,7 +11,6 @@
 
 set -euo pipefail
 
-
 # shellcheck source=runners/libs/init-vars.lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/libs/init-vars.lib.sh"
 

--- a/runners/run-shfmt.sh
+++ b/runners/run-shfmt.sh
@@ -48,4 +48,3 @@ main() {
 if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
   main "$@"
 fi
-


### PR DESCRIPTION
## Overview

**Summary**
Fix `resolve-sha.sh` so `BEFORE_SHA` is the head commit's parent, not a 5-generation-old ancestor.

**Background / Motivation**
On `workflow_dispatch`, `resolve-sha.sh` ran `git rev-list --parents -n 5 HEAD` and read `BEFORE_SHA`
from `tail -n 1`. That only works if the output is one line. With `-n 5` it is up to five lines, so
`tail -n 1` returned the fifth commit's own SHA instead of `HEAD^1`.

This broke real runs. Article lint compared `<5 commits back>..HEAD` instead of `HEAD^1..HEAD`, so it
linted articles that had not changed.

The design in `implementation.md:82-90` already said to use `-n 1` and `HEAD^1`. The code had drifted
from it. This PR brings the code back in line.

The old test stub returned a single line. On one line `head -n 1` and `tail -n 1` are the same line,
so the test could not catch the bug.

## Changes

### Core Changes

- `.github/workflows/scripts/resolve-sha.sh`: change `-n 5` to `-n 1`, then read `AFTER_SHA` from
  field 1 and `BEFORE_SHA` from field 2 of the HEAD line. Field 2 is `HEAD^1`. The initial-commit
  check (`_field_count -ge 2`) still works: an initial commit has 1 field, a normal commit 2, a merge
  commit 3.
- `.claude/settings.json`: move `Bash(git switch:*)` to another allow-list section, away from the
  `git checkout` group. Unrelated to #173.
- `runners/run-shellspec.sh`, `runners/run-shfmt.sh`: remove stray blank lines. Unrelated to #173.

### Test Updates

- `.github/workflows/scripts/__tests__/unit/resolve_sha.unit.spec.sh`: make the `git` stub return
  several `"<commit> <parent>"` lines so the old code fails the test. Add a comment saying only the
  first line is HEAD.

### Removed

- The `tail -n 1` extraction in `resolve-sha.sh`.

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [ ] Documentation
- [x] Configuration
- [x] CI/CD
- [ ] Other

## Related Issues

> Closes #173

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`) — `dprint check` passes on the
      five changed files. `pnpm run lint:sh` (shellcheck) and `pnpm run check:sh` (shfmt) pass.
- [x] Tests pass (if test suite exists) — `resolve_sha.unit.spec.sh`: 13 examples, 0 failures.
      Full unit suite: 25 examples, 0 failures.
- [ ] Documentation updated (for user-facing changes) — not needed, see Additional Notes
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Breaking Change

None.

## Additional Notes

- **No design doc change needed.** Issue #173 lists `implementation.md` and `tasks.md` as affected,
  but the design was already right. `implementation.md:82-90` specified `-n 1` and `HEAD^1` from the
  start. Only the code was wrong, so both documents stay as they are.

- **Two unrelated commits are included.** `bbc8fb5` (settings.json) and `c3f3566` (blank lines in the
  runner scripts) are not part of #173. They are small and were already on the branch, so splitting
  them into a separate PR did not seem worth it. Noting it so the diff is not read as bugfix-only.

- **All checks were run locally.** No CI job runs the ShellSpec suite yet, so the test, shellcheck,
  and shfmt results above come from local runs.

- `dprint check` on the whole repo reports 110 unformatted files. All of them are existing article and
  doc files this branch does not touch. The five changed files pass.

- Written as a BDD RGR cycle: the multi-line stub made the test red first, then the `resolve-sha.sh`
  fix made it green.
