### PR TITLE
ci(workflows): pin ci-platform actions to v0.3.3 and bump agla-doc-tools to v0.2.0

### DIFF
--- a/.github/workflows/ci-lint-articles.yaml
+++ b/.github/workflows/ci-lint-articles.yaml
@@ -19,6 +19,19 @@ on:
     paths:
       - "**/*.md"
   workflow_dispatch:
+    inputs:
+      fetch-depth:
+        description: "checkout fetch-depth (0 = full history)"
+        type: string
+        required: false
+        default: "0"
+  workflow_call:
+    inputs:
+      fetch-depth:
+        description: "checkout fetch-depth (0 = full history)"
+        type: string
+        required: false
+        default: "0"
 
 jobs:
   lint-on-github:
@@ -28,15 +41,20 @@ jobs:
     permissions:
       contents: read
 
+    env:
+      # inputs is unset on push/pull_request, so the trigger-level default does not apply there.
+      # The `|| '0'` fallback keeps those events on a full clone, which ca-get-changed-files requires.
+      FETCH_DEPTH: ${{ inputs.fetch-depth || '0' }}
+
     steps:
       - id: checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 30
+          fetch-depth: ${{ env.FETCH_DEPTH }}
           persist-credentials: false
 
       - id: validate-env
-        uses: aglabo/ci-platform/.github/actions/ca-validate-environment@8d63776a598f98913915e57b74e63ba5d06d5a47 # main
+        uses: aglabo/ci-platform/.github/actions/ca-validate-environment@d49d96532dbf95a356a5756864fa45e33a0fa033 # v0.3.4
         with:
           actions-type: read
 
@@ -47,19 +65,23 @@ jobs:
 
       - id: changed-files
         if: steps.resolve-sha.outputs.skip != 'true'
-        uses: aglabo/ci-platform/.github/actions/ca-get-changed-files@8d63776a598f98913915e57b74e63ba5d06d5a47 # main
+        uses: aglabo/ci-platform/.github/actions/ca-get-changed-files@d49d96532dbf95a356a5756864fa45e33a0fa033 # v0.3.4
         with:
           pattern: "**/*.md"
-          before-sha: ${{ env.BEFORE_SHA }}
-          after-sha: ${{ env.AFTER_SHA }}
+          before-sha: ${{ steps.resolve-sha.outputs.before_sha }}
+          after-sha: ${{ steps.resolve-sha.outputs.after_sha }}
 
       - id: setup-repo
         if: steps.resolve-sha.outputs.skip != 'true'
-        uses: aglabo/ci-platform/.github/actions/ca-setup-repo@8d63776a598f98913915e57b74e63ba5d06d5a47 # main
+        uses: aglabo/ci-platform/.github/actions/ca-setup-repo@d49d96532dbf95a356a5756864fa45e33a0fa033 # v0.3.4
         with:
           repo: aglabo/agla-doc-tools
           path: ./.tools/agla-doc-tools
-          ref: bec772fc1d22fbf43fd57ef3a71f7972b83b3e24 # v0.1.1
+          ref: 65055a58be00ace993489273fe2a037d1ec1468d # v0.2.0
+          node-version: "24"
+          # Must match packageManager in package.json exactly; pnpm/action-setup
+          # errors out when the two differ.
+          pnpm-version: "11.20.0"
 
       - id: lint
         if: steps.resolve-sha.outputs.skip != 'true'

--- a/.github/workflows/ci-scan-secrets.yml
+++ b/.github/workflows/ci-scan-secrets.yml
@@ -28,4 +28,4 @@ jobs:
     name: Betterleaks Secret Scan
     permissions:
       contents: read
-    uses: aglabo/ci-platform/.github/workflows/ci-scan-betterleaks.yml@2ac45debcb9c2902597abda02bcce3e6ff0121f0 # v0.2.1
+    uses: aglabo/ci-platform/.github/workflows/ru-scan-betterleaks.yml@d49d96532dbf95a356a5756864fa45e33a0fa033 # v0.3.4

--- a/.github/workflows/ci-workflows-qa.yml
+++ b/.github/workflows/ci-workflows-qa.yml
@@ -32,10 +32,10 @@ jobs:
     name: Actionlint
     permissions:
       contents: read
-    uses: aglabo/ci-platform/.github/workflows/ci-qa-actionlint.yml@2ac45debcb9c2902597abda02bcce3e6ff0121f0 # v0.2.1
+    uses: aglabo/ci-platform/.github/workflows/ru-qa-actionlint.yml@d49d96532dbf95a356a5756864fa45e33a0fa033 # v0.3.4
 
   ghalint:
     name: Ghalint
     permissions:
       contents: read
-    uses: aglabo/ci-platform/.github/workflows/ci-qa-ghalint.yml@2ac45debcb9c2902597abda02bcce3e6ff0121f0 # v0.2.1
+    uses: aglabo/ci-platform/.github/workflows/ru-qa-ghalint.yml@d49d96532dbf95a356a5756864fa45e33a0fa033 # v0.3.4

--- a/.github/workflows/scripts/__tests__/unit/resolve_sha.unit.spec.sh
+++ b/.github/workflows/scripts/__tests__/unit/resolve_sha.unit.spec.sh
@@ -14,26 +14,34 @@ _SCRIPT="${SHELLSPEC_PROJECT_ROOT}/.github/workflows/scripts/resolve-sha.sh"
 Describe 'resolve-sha.sh'
   Describe 'Given: workflow_dispatch event with parent commit'
     setup() {
-      # Create temp files for GITHUB_ENV and GITHUB_OUTPUT
-      GITHUB_ENV=$(mktemp)
       GITHUB_OUTPUT=$(mktemp)
-      export GITHUB_ENV GITHUB_OUTPUT
+      export GITHUB_OUTPUT
 
       # Create a temp directory for PATH-based git stub
       STUB_DIR=$(mktemp -d)
       export STUB_DIR
 
-      # Stub git to return multiple lines of "<commit> <parent>" pairs.
+      # Stub git: rev-list returns multiple lines of "<commit> <parent>" pairs.
       # Only the first line describes HEAD; later lines are older ancestors and
-      # must never be used for BEFORE_SHA/AFTER_SHA.
-      printf '#!/bin/sh\necho "abc123def456 parentsha123"\necho "parentsha123 grandparent789"\necho "grandparent789 greatgrand000"\n' > "$STUB_DIR/git"
+      # must never be used for before_sha/after_sha.
+      cat > "$STUB_DIR/git" <<'STUB'
+#!/bin/sh
+case "$1" in
+rev-list)
+  echo "abc123def456 parentsha123"
+  echo "parentsha123 grandparent789"
+  echo "grandparent789 greatgrand000"
+  ;;
+rev-parse) echo "false" ;;
+esac
+STUB
       chmod +x "$STUB_DIR/git"
 
       export PATH="$STUB_DIR:$PATH"
       export EVENT_NAME="workflow_dispatch"
     }
     cleanup() {
-      rm -f "$GITHUB_ENV" "$GITHUB_OUTPUT"
+      rm -f "$GITHUB_OUTPUT"
       rm -rf "$STUB_DIR"
     }
     Before 'setup'
@@ -41,14 +49,14 @@ Describe 'resolve-sha.sh'
 
     Describe 'When: resolve-sha script is executed'
       Describe 'Then: Task T-02-01 - workflow_dispatch with parent commit'
-        It 'writes BEFORE_SHA=parentsha123 to GITHUB_ENV'
+        It 'writes before_sha=parentsha123 to GITHUB_OUTPUT'
           When run script "$_SCRIPT"
-          The contents of file "$GITHUB_ENV" should include "BEFORE_SHA=parentsha123"
+          The contents of file "$GITHUB_OUTPUT" should include "before_sha=parentsha123"
         End
 
-        It 'writes AFTER_SHA=abc123def456 to GITHUB_ENV'
+        It 'writes after_sha=abc123def456 to GITHUB_OUTPUT'
           When run script "$_SCRIPT"
-          The contents of file "$GITHUB_ENV" should include "AFTER_SHA=abc123def456"
+          The contents of file "$GITHUB_OUTPUT" should include "after_sha=abc123def456"
         End
 
         It 'writes skip=false to GITHUB_OUTPUT'
@@ -59,24 +67,77 @@ Describe 'resolve-sha.sh'
     End
   End
 
-  Describe 'Given: workflow_dispatch event with no parent commit (initial commit)'
-    setup_no_parent() {
-      GITHUB_ENV=$(mktemp)
+  Describe 'Given: schedule event with parent commit'
+    setup_schedule() {
       GITHUB_OUTPUT=$(mktemp)
-      export GITHUB_ENV GITHUB_OUTPUT
+      export GITHUB_OUTPUT
 
       STUB_DIR=$(mktemp -d)
       export STUB_DIR
 
-      # Stub git to return 1 field only (no parent)
-      printf '#!/bin/sh\necho "abc123def456"\n' > "$STUB_DIR/git"
+      cat > "$STUB_DIR/git" <<'STUB'
+#!/bin/sh
+case "$1" in
+rev-list) echo "abc123def456 parentsha123" ;;
+rev-parse) echo "false" ;;
+esac
+STUB
+      chmod +x "$STUB_DIR/git"
+
+      export PATH="$STUB_DIR:$PATH"
+      export EVENT_NAME="schedule"
+    }
+    cleanup_schedule() {
+      rm -f "$GITHUB_OUTPUT"
+      rm -rf "$STUB_DIR"
+    }
+    Before 'setup_schedule'
+    After 'cleanup_schedule'
+
+    Describe 'When: resolve-sha script is executed'
+      Describe 'Then: Task T-02-05 - non push/PR event resolves SHA itself'
+        It 'writes the resolved before_sha to GITHUB_OUTPUT'
+          When run script "$_SCRIPT"
+          The line 1 of contents of file "$GITHUB_OUTPUT" should equal "before_sha=parentsha123"
+        End
+
+        It 'writes the resolved after_sha to GITHUB_OUTPUT'
+          When run script "$_SCRIPT"
+          The line 2 of contents of file "$GITHUB_OUTPUT" should equal "after_sha=abc123def456"
+        End
+
+        It 'writes skip=false to GITHUB_OUTPUT'
+          When run script "$_SCRIPT"
+          The contents of file "$GITHUB_OUTPUT" should include "skip=false"
+        End
+      End
+    End
+  End
+
+  Describe 'Given: non push/PR event with no parent commit on a full clone'
+    setup_no_parent() {
+      GITHUB_OUTPUT=$(mktemp)
+      export GITHUB_OUTPUT
+
+      STUB_DIR=$(mktemp -d)
+      export STUB_DIR
+
+      # Stub git: rev-list returns 1 field only (no parent),
+      # rev-parse reports a full (non-shallow) clone -> a true initial commit.
+      cat > "$STUB_DIR/git" <<'STUB'
+#!/bin/sh
+case "$1" in
+rev-list) echo "abc123def456" ;;
+rev-parse) echo "false" ;;
+esac
+STUB
       chmod +x "$STUB_DIR/git"
 
       export PATH="$STUB_DIR:$PATH"
       export EVENT_NAME="workflow_dispatch"
     }
     cleanup_no_parent() {
-      rm -f "$GITHUB_ENV" "$GITHUB_OUTPUT"
+      rm -f "$GITHUB_OUTPUT"
       rm -rf "$STUB_DIR"
     }
     Before 'setup_no_parent'
@@ -104,11 +165,63 @@ Describe 'resolve-sha.sh'
     End
   End
 
-  Describe 'Given: workflow_dispatch event and git command fails'
-    setup_git_fail() {
-      GITHUB_ENV=$(mktemp)
+  Describe 'Given: non push/PR event with no parent commit on a shallow clone'
+    setup_shallow() {
       GITHUB_OUTPUT=$(mktemp)
-      export GITHUB_ENV GITHUB_OUTPUT
+      export GITHUB_OUTPUT
+
+      STUB_DIR=$(mktemp -d)
+      export STUB_DIR
+
+      # Stub git: rev-list returns 1 field only, but rev-parse reports a shallow
+      # clone -> the parent exists upstream and is merely not fetched.
+      cat > "$STUB_DIR/git" <<'STUB'
+#!/bin/sh
+case "$1" in
+rev-list) echo "abc123def456" ;;
+rev-parse) echo "true" ;;
+esac
+STUB
+      chmod +x "$STUB_DIR/git"
+
+      export PATH="$STUB_DIR:$PATH"
+      export EVENT_NAME="workflow_dispatch"
+    }
+    cleanup_shallow() {
+      rm -f "$GITHUB_OUTPUT"
+      rm -rf "$STUB_DIR"
+    }
+    Before 'setup_shallow'
+    After 'cleanup_shallow'
+
+    Describe 'When: resolve-sha script is executed'
+      Describe 'Then: Task T-02-06 - shallow clone must not be treated as initial commit'
+        It 'exits with non-zero status'
+          When run script "$_SCRIPT"
+          The stderr should include "error"
+          The status should be failure
+        End
+
+        It 'outputs an error message'
+          When run script "$_SCRIPT"
+          The status should be failure
+          The stderr should include "error"
+        End
+
+        It 'does not write skip=true to GITHUB_OUTPUT'
+          When run script "$_SCRIPT"
+          The stderr should include "error"
+          The status should be failure
+          The contents of file "$GITHUB_OUTPUT" should not include "skip=true"
+        End
+      End
+    End
+  End
+
+  Describe 'Given: non push/PR event and git command fails'
+    setup_git_fail() {
+      GITHUB_OUTPUT=$(mktemp)
+      export GITHUB_OUTPUT
 
       STUB_DIR=$(mktemp -d)
       export STUB_DIR
@@ -121,7 +234,7 @@ Describe 'resolve-sha.sh'
       export EVENT_NAME="workflow_dispatch"
     }
     cleanup_git_fail() {
-      rm -f "$GITHUB_ENV" "$GITHUB_OUTPUT"
+      rm -f "$GITHUB_OUTPUT"
       rm -rf "$STUB_DIR"
     }
     Before 'setup_git_fail'
@@ -139,32 +252,31 @@ Describe 'resolve-sha.sh'
 
   Describe 'Given: push event'
     setup_push() {
-      GITHUB_ENV=$(mktemp)
       GITHUB_OUTPUT=$(mktemp)
-      export GITHUB_ENV GITHUB_OUTPUT
+      export GITHUB_OUTPUT
       export EVENT_NAME="push"
     }
     cleanup_push() {
-      rm -f "$GITHUB_ENV" "$GITHUB_OUTPUT"
+      rm -f "$GITHUB_OUTPUT"
     }
     Before 'setup_push'
     After 'cleanup_push'
 
     Describe 'When: resolve-sha script is executed'
-      Describe 'Then: Task T-02-02 - push event with empty SHA'
-        It 'writes BEFORE_SHA= (empty) to GITHUB_ENV'
+      Describe 'Then: Task T-02-02 - push event delegates to upstream action'
+        It 'writes an empty before_sha to GITHUB_OUTPUT'
           When run script "$_SCRIPT"
-          The contents of file "$GITHUB_ENV" should include "BEFORE_SHA="
+          The line 1 of contents of file "$GITHUB_OUTPUT" should equal "before_sha="
         End
 
-        It 'writes AFTER_SHA= (empty) to GITHUB_ENV'
+        It 'writes an empty after_sha to GITHUB_OUTPUT'
           When run script "$_SCRIPT"
-          The contents of file "$GITHUB_ENV" should include "AFTER_SHA="
+          The line 2 of contents of file "$GITHUB_OUTPUT" should equal "after_sha="
         End
 
         It 'writes skip=false to GITHUB_OUTPUT'
           When run script "$_SCRIPT"
-          The contents of file "$GITHUB_OUTPUT" should include "skip=false"
+          The line 3 of contents of file "$GITHUB_OUTPUT" should equal "skip=false"
         End
       End
     End
@@ -172,32 +284,31 @@ Describe 'resolve-sha.sh'
 
   Describe 'Given: pull_request event'
     setup_pr() {
-      GITHUB_ENV=$(mktemp)
       GITHUB_OUTPUT=$(mktemp)
-      export GITHUB_ENV GITHUB_OUTPUT
+      export GITHUB_OUTPUT
       export EVENT_NAME="pull_request"
     }
     cleanup_pr() {
-      rm -f "$GITHUB_ENV" "$GITHUB_OUTPUT"
+      rm -f "$GITHUB_OUTPUT"
     }
     Before 'setup_pr'
     After 'cleanup_pr'
 
     Describe 'When: resolve-sha script is executed'
-      Describe 'Then: Task T-02-02 - pull_request event with empty SHA'
-        It 'writes BEFORE_SHA= (empty) to GITHUB_ENV'
+      Describe 'Then: Task T-02-02 - pull_request event delegates to upstream action'
+        It 'writes an empty before_sha to GITHUB_OUTPUT'
           When run script "$_SCRIPT"
-          The contents of file "$GITHUB_ENV" should include "BEFORE_SHA="
+          The line 1 of contents of file "$GITHUB_OUTPUT" should equal "before_sha="
         End
 
-        It 'writes AFTER_SHA= (empty) to GITHUB_ENV'
+        It 'writes an empty after_sha to GITHUB_OUTPUT'
           When run script "$_SCRIPT"
-          The contents of file "$GITHUB_ENV" should include "AFTER_SHA="
+          The line 2 of contents of file "$GITHUB_OUTPUT" should equal "after_sha="
         End
 
         It 'writes skip=false to GITHUB_OUTPUT'
           When run script "$_SCRIPT"
-          The contents of file "$GITHUB_OUTPUT" should include "skip=false"
+          The line 3 of contents of file "$GITHUB_OUTPUT" should equal "skip=false"
         End
       End
     End

--- a/.github/workflows/scripts/resolve-sha.sh
+++ b/.github/workflows/scripts/resolve-sha.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # scripts/resolve-sha.sh
-# @(#) : Resolve BEFORE_SHA and AFTER_SHA for GitHub Actions
+# @(#) : Resolve before_sha and after_sha outputs for GitHub Actions
 #
 # Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
 #
@@ -9,9 +9,18 @@
 
 set -euo pipefail
 
-if [ "${EVENT_NAME:-}" = "workflow_dispatch" ]; then
+case "${EVENT_NAME:-}" in
+push | pull_request)
+  # Leave both SHAs empty and let ca-get-changed-files resolve the range itself.
+  {
+    echo "before_sha="
+    echo "after_sha="
+    echo "skip=false"
+  } >>"${GITHUB_OUTPUT}"
+  ;;
+*) # any other event (workflow_dispatch, schedule, release, ...): resolve the range here
   # "<commit> <parent>..." for HEAD only: field 1 is HEAD, field 2 is its first parent.
-  # An initial commit has no parent, so the line holds a single field.
+  # A commit with no visible parent yields a single field.
   _parents=$(git rev-list --parents -n 1 HEAD)
   _head_line=$(echo "$_parents" | head -n 1)
   _field_count=$(echo "$_head_line" | wc -w)
@@ -19,16 +28,20 @@ if [ "${EVENT_NAME:-}" = "workflow_dispatch" ]; then
   if [ "$_field_count" -ge 2 ]; then
     _after_sha=$(echo "$_head_line" | cut -d' ' -f1)
     _before_sha=$(echo "$_head_line" | cut -d' ' -f2)
-    echo "BEFORE_SHA=${_before_sha}" >>"${GITHUB_ENV}"
-    echo "AFTER_SHA=${_after_sha}" >>"${GITHUB_ENV}"
-    echo "skip=false" >>"${GITHUB_OUTPUT}"
+    {
+      echo "before_sha=${_before_sha}"
+      echo "after_sha=${_after_sha}"
+      echo "skip=false"
+    } >>"${GITHUB_OUTPUT}"
+  elif [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+    # The parent exists upstream but was never fetched. Skipping here would let
+    # the lint silently pass, so fail instead.
+    echo "::error::Shallow clone: cannot resolve the parent commit. Fetch more history." >&2
+    exit 1
   else
     echo "::warning::No parent commit found. Skipping lint." >&2
     echo "skip=true" >>"${GITHUB_OUTPUT}"
     exit 0
   fi
-else # other events: PUSH, PullRequest
-  echo "BEFORE_SHA=" >>"${GITHUB_ENV}"
-  echo "AFTER_SHA=" >>"${GITHUB_ENV}"
-  echo "skip=false" >>"${GITHUB_OUTPUT}"
-fi
+  ;;
+esac

--- a/.shellspec
+++ b/.shellspec
@@ -18,32 +18,37 @@
 # === Base Configuration ===
 # Core testing setup: helpers, sandbox, and example handling
 
-# shell
+# Set shell to bash
 --shell bash
 
-# File Pattern
+# Spec file pattern (match .spec.sh instead of _spec.sh)
 --pattern "*.spec.sh"
 
-# Report format (detailed output for CI logs)
---format documentation
-
-# Enable color output
+# Enable colored output
 --color
 
-# Execution directory (run from spec file location for relative imports)
---execdir @specfile
+# Show execution times
+# --profile
+--profile-limit=10
 
-# Skip message severity (moderate = hide skipped test details)
---skip-message moderate
+# Set formatter (default: progress, options: documentation, tap, junit)
+--format documentation
 
 # Fail if no examples found (prevent silent failures)
 --fail-no-examples
 
-# Don't treat warnings as failures (allow exit code 0 with warnings)
---no-warning-as-failure
+# Coverage settings (requires kcov)
+# --kcov
+# --kcov-options "--exclude-pattern=/usr"
 
-# === Parallel Execution ===
-# Spec file parallel execution
+# Execution options
 # @note: use in Windows is dangerous.
 --jobs 4
 
+# --random none
+
+# Output directory for reports
+--reportdir "temp/shellspec-reports"
+
+# Warning settings
+--warning-as-failure

--- a/docs/.deckrd/workflows/lint-article/implementation/implementation.md
+++ b/docs/.deckrd/workflows/lint-article/implementation/implementation.md
@@ -4,7 +4,7 @@ title: "Implementation: ci-lint-articles Composite Action Migration"
 spec: SPEC-001
 req: REQ-001
 status: Draft
-version: 1.0.4
+version: 1.0.6
 created: "2026-06-23"
 ---
 
@@ -19,8 +19,8 @@ created: "2026-06-23"
 
 **対象ドキュメント**:
 
-- Spec: `specifications/specifications.md` v1.0.5
-- Req: `requirements/requirements.md` v1.0.6
+- Spec: `specifications/specifications.md` v1.0.7
+- Req: `requirements/requirements.md` v1.0.7
 
 ---
 
@@ -43,15 +43,19 @@ created: "2026-06-23"
 | Action                    | Repository           | SHA                                        | Comment    |
 | ------------------------- | -------------------- | ------------------------------------------ | ---------- |
 | `actions/checkout`        | `actions/checkout`   | `df4cb1c069e1874edd31b4311f1884172cec0e10` | `# v6.0.3` |
-| `ca-validate-environment` | `aglabo/ci-platform` | `8d63776a598f98913915e57b74e63ba5d06d5a47` | `# main`   |
-| `ca-get-changed-files`    | `aglabo/ci-platform` | `8d63776a598f98913915e57b74e63ba5d06d5a47` | `# main`   |
-| `ca-setup-repo`           | `aglabo/ci-platform` | `8d63776a598f98913915e57b74e63ba5d06d5a47` | `# main`   |
+| `ca-validate-environment` | `aglabo/ci-platform` | `9cc4b15bf10854ecc0fc2ea0a419d96566ea8bde` | `# v0.3.3` |
+| `ca-get-changed-files`    | `aglabo/ci-platform` | `9cc4b15bf10854ecc0fc2ea0a419d96566ea8bde` | `# v0.3.3` |
+| `ca-setup-repo`           | `aglabo/ci-platform` | `9cc4b15bf10854ecc0fc2ea0a419d96566ea8bde` | `# v0.3.3` |
 
 `ca-setup-repo` の `ref` (agla-doc-tools のチェックアウト SHA):
 
 | Repository              | SHA                                        | Comment    |
 | ----------------------- | ------------------------------------------ | ---------- |
-| `aglabo/agla-doc-tools` | `bec772fc1d22fbf43fd57ef3a71f7972b83b3e24` | `# v0.1.1` |
+| `aglabo/agla-doc-tools` | `65055a58be00ace993489273fe2a037d1ec1468d` | `# v0.2.0` |
+
+v0.2.0 は `engines` に `node >=24`、`pnpm >=11` を要求するため、`ca-setup-repo` のデフォルト
+(`node-version: "22"`、`pnpm-version: "10"`) では `pnpm install --frozen-lockfile` が失敗する。
+`node-version: "24"` と `pnpm-version: "11"` を明示的に渡さなければならない (MUST) 。
 
 #### 2.3 Workflow Structure
 
@@ -59,7 +63,12 @@ created: "2026-06-23"
 triggers:
   - push: branches=[main], paths=['**/*.md']
   - pull_request: branches=[main], paths=['**/*.md']
-  - workflow_dispatch
+  - workflow_dispatch:
+      inputs:
+        fetch-depth: {type: string, required: false, default: "0"}
+  - workflow_call:
+      inputs:
+        fetch-depth: {type: string, required: false, default: "0"}
 
 jobs:
   lint-on-github:
@@ -68,11 +77,15 @@ jobs:
     permissions:
       contents: read
 
+    env:
+      # inputs is unset on push/pull_request -> the trigger-level default does not apply there
+      FETCH_DEPTH: ${{ inputs.fetch-depth || '0' }}
+
     steps:
       1. id: checkout
          uses: actions/checkout@df4cb1c... # v6.0.3
          with:
-           fetch-depth: 0
+           fetch-depth: ${{ env.FETCH_DEPTH }}
            persist-credentials: false
 
       2. id: validate-env
@@ -80,35 +93,44 @@ jobs:
          with: actions-type: read
 
       3. id: resolve-sha  (run step)
-         初回コミット判定: git rev-list --parents -n 1 HEAD でparent数を取得
-         - workflow_dispatch + parent数 == 0 (初回コミット) ->
-             echo "skip=true" >> $GITHUB_OUTPUT
-             warning log + exit 0
-         - workflow_dispatch + parent数 >= 1 ->
-             echo "BEFORE_SHA=$(git rev-parse HEAD^1)" >> $GITHUB_ENV
-             echo "AFTER_SHA=$(git rev-parse HEAD)"    >> $GITHUB_ENV
-             echo "skip=false" >> $GITHUB_OUTPUT
-         - workflow_dispatch + git コマンド失敗 -> exit non-zero
+         分岐は「push / pull_request か否か」で行う
          - push / pull_request ->
-             echo "BEFORE_SHA=" >> $GITHUB_ENV
-             echo "AFTER_SHA="  >> $GITHUB_ENV
-             echo "skip=false" >> $GITHUB_OUTPUT
+             echo "before_sha=" >> $GITHUB_OUTPUT
+             echo "after_sha="  >> $GITHUB_OUTPUT
+             echo "skip=false"  >> $GITHUB_OUTPUT
+             ※ 両方空にして ca-get-changed-files の自動解決に委譲する
+         - それ以外 (workflow_dispatch / workflow_call 由来の schedule, release 等):
+           git rev-list --parents -n 1 HEAD の先頭行でparent数を取得
+           - parent数 >= 1 ->
+               echo "before_sha=<第2フィールド>" >> $GITHUB_OUTPUT
+               echo "after_sha=<第1フィールド>"  >> $GITHUB_OUTPUT
+               echo "skip=false" >> $GITHUB_OUTPUT
+           - parent数 == 0 かつ git rev-parse --is-shallow-repository == false
+             (真の初回コミット) ->
+               echo "skip=true" >> $GITHUB_OUTPUT
+               warning log + exit 0
+           - parent数 == 0 かつ --is-shallow-repository == true
+             (shallow clone で親が未 fetch) ->
+               error log + exit non-zero
+           - git コマンド失敗 -> exit non-zero
 
       4. id: changed-files
          if: steps.resolve-sha.outputs.skip != 'true'
          uses: aglabo/ci-platform/.github/actions/ca-get-changed-files@f4e8d971... # v0.3.1+
          with:
            pattern: '**/*.md'
-           before-sha: ${{ env.BEFORE_SHA }}
-           after-sha:  ${{ env.AFTER_SHA }}
+           before-sha: ${{ steps.resolve-sha.outputs.before_sha }}
+           after-sha:  ${{ steps.resolve-sha.outputs.after_sha }}
 
       5. id: setup-repo
          if: steps.resolve-sha.outputs.skip != 'true'
-         uses: aglabo/ci-platform/.github/actions/ca-setup-repo@f4e8d971... # v0.3.1+
+         uses: aglabo/ci-platform/.github/actions/ca-setup-repo@9cc4b15b... # v0.3.3
          with:
            repo: aglabo/agla-doc-tools
            path: .tools/agla-doc-tools
-           ref: bec772fc1d22fbf43fd57ef3a71f7972b83b3e24 # v0.1.1
+           ref: 65055a58be00ace993489273fe2a037d1ec1468d # v0.2.0
+           node-version: "24"
+           pnpm-version: "11"
 
       6. id: lint  (run step)
          if: steps.resolve-sha.outputs.skip != 'true'
@@ -126,12 +148,14 @@ jobs:
 
 | Rule       | Implementation                                                                                                                                                                |
 | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| R-001a/b/c | on: push / pull_request / workflow_dispatch トリガー定義                                                                                                                      |
+| R-001a/b/c | on: push / pull_request / workflow_dispatch / workflow_call トリガー定義                                                                                                      |
 | R-001d     | paths フィルターで *.md 以外の push/PR はジョブ起動しない                                                                                                                     |
-| R-002a     | SHA 解決ステップ: `git rev-parse HEAD^1` 成功時に環境変数セット                                                                                                               |
+| R-002a     | SHA 解決ステップ: 非 push/PR イベントで parent が取得できた場合に `before_sha`/`after_sha` を GITHUB_OUTPUT へ出力                                                            |
 | R-002b     | SHA 解決ステップ: `git rev-list --parents -n 1 HEAD` で parent 数 == 0 → `skip=true` + warning + exit 0。後続ステップは `if: steps.resolve-sha.outputs.skip != 'true'` で制御 |
 | R-002c     | SHA 解決ステップ: その他 git エラー → exit non-zero                                                                                                                           |
-| R-002d     | push / PR 時は BEFORE_SHA="", AFTER_SHA="" で自動解決を委譲                                                                                                                   |
+| R-002d     | push / PR 時は `before_sha=""`, `after_sha=""` で自動解決を委譲                                                                                                               |
+| R-002e     | workflow_call 由来の非 push/PR イベント (schedule / release 等) も自前で SHA を解決する。空文字を渡すと上流が `Unsupported event` で失敗するため                              |
+| R-002f     | parent 数 == 0 の場合、`git rev-parse --is-shallow-repository` で真の初回コミットと shallow clone を切り分ける。shallow なら error + exit non-zero（黙ってスキップしない）    |
 | R-003      | ca-validate-environment を checkout 直後・他ステップより前に配置                                                                                                              |
 | R-004a/b   | ca-get-changed-files に before-sha / after-sha を渡す                                                                                                                         |
 | R-004c     | before-sha オールゼロ時のフォールバックは ca-get-changed-files が処理                                                                                                         |
@@ -145,13 +169,14 @@ jobs:
 #### 2.5 Implementation Notes
 
 - uses: パス形式: `aglabo/ci-platform/.github/actions/<action-name>@<SHA>` の形式で step-level で呼び出す
-- ステップ間の環境変数受け渡し: `echo "VAR=value" >> $GITHUB_ENV` で書き込み、次ステップで `${{ env.VAR }}` として参照する
-- ca-get-changed-files の outputs 参照: step `id: changed-files` を設定し、lint ステップで `${{ steps.changed-files.outputs.files }}` / `${{ steps.changed-files.outputs.count }}` を `env:` 経由で渡す
+- ステップ間の値の受け渡し: `echo "key=value" >> $GITHUB_OUTPUT` で書き込み、次ステップで `${{ steps.<id>.outputs.<key> }}` として参照する。`GITHUB_ENV` + `${{ env.VAR }}` は使わない — 実行時に生成される変数は静的解析で追えず、VS Code の GitHub Actions 拡張が「Context access might be invalid」を誤検知するため。上流の `ca-get-changed-files` 自身も outputs 方式を採っている
+- ca-get-changed-files の outputs 参照: step `id: changed-files` を設定し、lint ステップで `${{ steps.changed-files.outputs.files }}`/`${{ steps.changed-files.outputs.count }}` を `env:` 経由で渡す
 - セキュリティ: `actions/checkout` に `persist-credentials: false` を設定する。lint ツールは `textlint` と `markdownlint-cli2` を直接実行するため、PR 内スクリプト変更の影響を受けない
-- `ca-setup-repo` の `repo`: `aglabo/agla-doc-tools`、`path`: `.tools/agla-doc-tools`、`ref`: `bec772fc1d22fbf43fd57ef3a71f7972b83b3e24 # v0.1.1`
+- `ca-setup-repo` の `repo`: `aglabo/agla-doc-tools`、`path`: `.tools/agla-doc-tools`、`ref`: `65055a58be00ace993489273fe2a037d1ec1468d # v0.2.0`
 - `ca-setup-repo` は `bin/` を PATH に追加するため、`markdownlint-cli2` コマンドは `ca-setup-repo` 完了後にそのまま呼び出せる
-- 初回コミット判定: `git rev-list --parents -n 1 HEAD` の出力を空白で分割し、フィールド数が 1（親なし）なら初回コミットと判定する。exit code 128 による判定は他の git エラーと区別できないため使わない
-- スキップの伝播: resolve-sha ステップが初回コミットを検出した場合、`echo "skip=true" >> $GITHUB_OUTPUT` で出力し、後続の changed-files / setup-repo / lint 各ステップに `if: steps.resolve-sha.outputs.skip != 'true'` を付与してスキップさせる
+- 初回コミット判定: `git rev-list --parents -n 1 HEAD` の出力を空白で分割し、フィールド数が 1（親なし）なら親が見えないと判定する。exit code 128 による判定は他の git エラーと区別できないため使わない
+- shallow clone の切り分け: フィールド数が 1 でも、それが「真の初回コミット」か「shallow clone で親が未 fetch」かは区別できない。`fetch-depth` は `workflow_call` の caller が `"1"` を渡せるため後者は現実に起こる。shallow を初回コミットと誤認して `skip=true` にするとリントが黙って実行されないまま成功扱いになるので、`git rev-parse --is-shallow-repository` で判定し shallow 側は exit non-zero で明示的に失敗させる（fail-first）
+- スキップの伝播: resolve-sha ステップが初回コミットを検出した場合、`echo "skip=true" >> $GITHUB_OUTPUT` で出力し、後続の changed-files/setup-repo/lint 各ステップに `if: steps.resolve-sha.outputs.skip != 'true'` を付与してスキップさせる
 - outputs.files の展開: `echo "$CHANGED_FILES"` ではなく `printf '%s\n' "$CHANGED_FILES"` を使い、先頭ハイフンやオプション風文字列の誤解釈を防ぐ
 - CHANGED_COUNT の型チェック: lint ステップ内で `[[ "$CHANGED_COUNT" =~ ^[0-9]+$ ]]` で数値検証し、不正値の場合は exit non-zero とする
 - GitHub Actions の `run:` ブロックは `bash --noprofile --norc -eo pipefail` で実行されるため、fail-fast（R-005f）は `set -e` を明示しなくても動作する
@@ -185,24 +210,26 @@ Req: REQ-001
 
 実装完了の判定条件:
 
-| # | Criterion                                                                     | How to Verify                          |
-| - | ----------------------------------------------------------------------------- | -------------------------------------- |
-| 1 | YAML 構文が正しい                                                             | `actionlint` / `yamllint` でエラーなし |
-| 2 | fetch-depth が 0 に設定されている                                             | yaml 内を目視確認                      |
-| 3 | ca-validate-environment が checkout の直後に配置されている                    | ステップ順序を目視確認                 |
-| 4 | 全 Action が commit SHA で固定されている                                      | `@SHA # vX.Y.Z` コメント形式を目視確認 |
-| 5 | SHA 解決ステップが R-002a/b/c/d を網羅している                                | スクリプトロジックを目視確認           |
-| 6 | lint ステップが count==0 スキップ・削除済みスキップ・fail-fast を実装している | スクリプトロジックを目視確認           |
-| 7 | push / PR / workflow_dispatch の各トリガーが正しく設定されている              | yaml を目視確認                        |
+| # | Criterion                                                                        | How to Verify                                                                                                                                                                  |
+| - | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1 | YAML 構文が正しい                                                                | `actionlint` / `yamllint` でエラーなし                                                                                                                                         |
+| 2 | fetch-depth が未指定時に 0 に解決される                                          | `env.FETCH_DEPTH` が `${{ inputs.fetch-depth \|\| '0' }}` であり、checkout がその env を参照していることを目視確認。push 実行時の checkout ログで解決値が `0` になることを確認 |
+| 3 | ca-validate-environment が checkout の直後に配置されている                       | ステップ順序を目視確認                                                                                                                                                         |
+| 4 | 全 Action が commit SHA で固定されている                                         | `@SHA # vX.Y.Z` コメント形式を目視確認                                                                                                                                         |
+| 5 | SHA 解決ステップが R-002a/b/c/d を網羅している                                   | スクリプトロジックを目視確認                                                                                                                                                   |
+| 6 | lint ステップが count==0 スキップ・削除済みスキップ・fail-fast を実装している    | スクリプトロジックを目視確認                                                                                                                                                   |
+| 7 | push / PR / workflow_dispatch / workflow_call の各トリガーが正しく設定されている | yaml を目視確認                                                                                                                                                                |
 
 ---
 
 ## 5. Change History
 
-| Date       | Version | Description                                                                                                                                                                     |
-| ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 2026-06-23 | 1.0.0   | Initial draft                                                                                                                                                                   |
-| 2026-06-23 | 1.0.1   | explore review 対応: agla-doc-tools SHA 確定 (v0.1.0) 、path `.tools/agla-doc-tools` 追加、markdownlint-cli2 PATH 経路を明記                                                    |
-| 2026-06-23 | 1.0.2   | explore review (2nd) 対応: uses: パス形式・GITHUB_ENV 受け渡し・outputs 参照方式・step id を Section 2.3/2.5 に追記                                                             |
-| 2026-06-23 | 1.0.3   | Codex risk review 対応: 初回コミット判定を exit code 128 から git rev-list --parents に変更、skip=true による後続ステップ制御、printf '%s\n' 展開、CHANGED_COUNT 数値検証を追加 |
-| 2026-06-23 | 1.0.4   | Codex balanced review 対応: checkout に persist-credentials: false 追加。Composite Action 契約・実行環境検証は自作 action / ca-validate-environment で対応済みとして記録        |
+| Date       | Version | Description                                                                                                                                                                                                                                            |
+| ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 2026-06-23 | 1.0.0   | Initial draft                                                                                                                                                                                                                                          |
+| 2026-06-23 | 1.0.1   | explore review 対応: agla-doc-tools SHA 確定 (v0.1.0) 、path `.tools/agla-doc-tools` 追加、markdownlint-cli2 PATH 経路を明記                                                                                                                           |
+| 2026-06-23 | 1.0.2   | explore review (2nd) 対応: uses: パス形式・GITHUB_ENV 受け渡し・outputs 参照方式・step id を Section 2.3/2.5 に追記                                                                                                                                    |
+| 2026-06-23 | 1.0.3   | Codex risk review 対応: 初回コミット判定を exit code 128 から git rev-list --parents に変更、skip=true による後続ステップ制御、printf '%s\n' 展開、CHANGED_COUNT 数値検証を追加                                                                        |
+| 2026-06-23 | 1.0.4   | Codex balanced review 対応: checkout に persist-credentials: false 追加。Composite Action 契約・実行環境検証は自作 action / ca-validate-environment で対応済みとして記録                                                                               |
+| 2026-08-07 | 1.0.5   | fetch-depth をパラメータ化: workflow_dispatch / workflow_call の inputs 追加、ジョブレベル env.FETCH_DEPTH 経由で checkout に受け渡し、検証基準 #2 を更新                                                                                              |
+| 2026-08-07 | 1.0.6   | SHA 受け渡しを GITHUB_ENV から GITHUB_OUTPUT へ移行 (R-002 全体を改訂)。分岐を push/PR か否かに反転し workflow_call 由来の非 push/PR イベントに対応 (R-002e)。shallow clone を初回コミットと誤認しないよう --is-shallow-repository で切り分け (R-002f) |

--- a/docs/.deckrd/workflows/lint-article/requirements/requirements.md
+++ b/docs/.deckrd/workflows/lint-article/requirements/requirements.md
@@ -2,7 +2,7 @@
 title: "Requirements: ci-lint-articles Composite Action Migration"
 module: "workflows/lint-article"
 status: Draft
-version: 1.0.6
+version: 1.0.7
 created: "2026-06-22"
 ---
 
@@ -29,7 +29,7 @@ created: "2026-06-22"
 - `push: branches: [main], paths: ['**/*.md']` トリガーの追加
 - `workflow_dispatch` トリガーの追加 (before-sha = `github.sha^1`、after-sha = `github.sha` で変更ファイルを取得)
 - `ca-get-changed-files` の拡張 (SHA 指定済みの場合はそれを優先使用する動作を追加)
-- `ca-validate-environment` / `ca-get-changed-files` / `ca-setup-repo` の採用
+- `ca-validate-environment`/`ca-get-changed-files`/`ca-setup-repo` の採用
 - `pnpm run lint:text` と `pnpm run lint:markdown` による lint 実行
 
 **Out of Scope**:
@@ -44,10 +44,10 @@ created: "2026-06-22"
 - Target Environment: GitHub Actions (ubuntu-latest)
 - Related Components: `aglabo/ci-platform` (composite actions 提供元) 、`configs/textlintrc.yaml`、`configs/.markdownlint.yaml`
 - Assumptions:
-  - `aglabo/ci-platform` の composite actions は安定しており、`ca-get-changed-files` は push / pull_request どちらのトリガーでも動作する
+  - `aglabo/ci-platform` の composite actions は安定しており、`ca-get-changed-files` は push/pull_request どちらのトリガーでも動作する。ただし SHA 未指定での自動解決はこの 2 イベント **のみ** が対象であり、他イベントでは caller が SHA を明示的に渡す必要がある
   - `ca-get-changed-files` は push イベントでは `github.event.before` (before-sha) と `github.sha` (after-sha) を、pull_request イベントでは PR の base SHA (before-sha) と head SHA (after-sha) を使って変更ファイルリストを出力する
   - `ca-get-changed-files` は before-sha がオールゼロ (初回 push・新規ブランチ作成時) の場合、自動的に空ツリー SHA にフォールバックしてリポジトリ全ファイルとの差分を返す。caller 側での特別処理は不要
-  - `ca-setup-repo` は Node.js / pnpm のセットアップと `pnpm install` まで行うため、別途インストールステップは不要
+  - `ca-setup-repo` は Node.js/pnpm のセットアップと `pnpm install` まで行うため、別途インストールステップは不要
 
 ### System Context Diagram
 
@@ -144,14 +144,16 @@ THEN the system SHALL ca-get-changed-files を呼び出して変更された *.m
 
 SHA 解決ルール (ca-get-changed-files の動作):
 
-- before-sha / after-sha が指定済みの場合はそれを優先使用する
-- 未指定の場合はイベント種別から自動取得する
+- before-sha/after-sha が指定済みの場合はそれを優先使用する
+- **両方とも** 未指定 (空文字) の場合のみイベント種別から自動取得する。片方だけ空だとエラーになる
   - push イベント: before-sha = `github.event.before`、after-sha = `github.sha`
   - pull_request イベント: before-sha = PR base SHA、after-sha = PR head SHA
+  - 上記 2 イベント以外で空文字を渡すと `Unsupported event` でジョブが失敗する
 
 caller 側の責務:
 
-- workflow_dispatch 時は caller が before-sha = `github.sha^1`、after-sha = `github.sha` を渡す
+- `push` / `pull_request` 以外のすべてのイベント (workflow_dispatch、および `workflow_call` 経由の schedule / release 等) では、caller が before-sha = 親コミット、after-sha = `HEAD` を自前で解決して渡す
+- 親コミットが取得できない場合、`git rev-parse --is-shallow-repository` で真の初回コミット (skip) と shallow clone (失敗) を切り分ける
 
 **Rationale**: 変更されたファイルのみを lint することで実行時間を短縮し、無関係なファイルへの誤検知を防ぐため。
 
@@ -215,20 +217,29 @@ THEN the system SHALL lint ステップをスキップし、warning メッセー
 - EARS Type: event-driven
 
 ```text
-GIVEN workflow_dispatch イベントが発生する
+GIVEN workflow_dispatch イベント、または workflow_call 経由の
+  push / pull_request 以外のイベント (schedule, release 等) が発生する
   WHEN lint ジョブが起動する
-THEN the system SHALL before-sha に github.sha^1 を、after-sha に github.sha を設定して
+THEN the system SHALL before-sha に HEAD の親コミットを、after-sha に HEAD を設定して
   ca-get-changed-files に渡し、変更された *.md ファイルをリストアップして lint を実行する。
+
+GIVEN 親コミットが取得できない
+  WHEN shallow clone である (git rev-parse --is-shallow-repository が true)
+THEN the system SHALL エラーログを出力してジョブを失敗させる (exit non-zero)。
+  ELSE 真の初回コミットとして warning ログを出力し lint をスキップして exit 0 する。
 ```
 
 **Rationale**: 手動実行時も最新コミットで変更されたファイルを、lint の対象にするため。
 
 **Acceptance Criteria**:
 
-| AC ID  | Scenario                                                             |
-| ------ | -------------------------------------------------------------------- |
-| AC-011 | workflow_dispatch 実行時に lint が起動する                           |
-| AC-012 | workflow_dispatch 時は github.sha^1 と github.sha の差分が対象になる |
+| AC ID  | Scenario                                                                                     |
+| ------ | -------------------------------------------------------------------------------------------- |
+| AC-011 | workflow_dispatch 実行時に lint が起動する                                                   |
+| AC-012 | workflow_dispatch 時は HEAD の親と HEAD の差分が対象になる                                   |
+| AC-013 | workflow_call 経由の schedule 等でも自前で SHA を解決し lint が実行される (空文字を渡さない) |
+| AC-014 | shallow clone で親が取得できない場合、skip せずジョブが失敗する                              |
+| AC-015 | push / pull_request では before_sha / after_sha が両方とも空文字で出力される                 |
 
 ## 5. Non-Functional Requirements
 
@@ -244,7 +255,13 @@ ci-platform の composite actions は外部リポジトリ (`aglabo/ci-platform`
 
 ### REQ-C-001: fetch-depth 制約
 
-`ca-get-changed-files` は git の履歴全体を必要とするため、`actions/checkout` の `fetch-depth` は `0` に設定しなければならない。
+`actions/checkout` の `fetch-depth` はデフォルト値を `0` (全履歴) としなければならない (MUST) 。`workflow_dispatch` および `workflow_call` の入力パラメータによる上書きを許容する。
+
+この入力パラメータを受け取るため、`workflow_call` トリガーを定義する。`workflow_call` は `fetch-depth` パラメータの受け渡しのみを目的とし、他の再利用用途は想定しない。
+
+`ca-get-changed-files` は任意の 2 つの SHA 間の diff を計算するため、原則として git の履歴全体を必要とする。`fetch-depth` を短縮した場合、比較対象の SHA がローカルに存在せず `ca-get-changed-files` が失敗するリスクがある。短縮値の指定は、対象コミット範囲が浅いことを呼び出し側が把握している場合に限る。
+
+なお `workflow_dispatch` では SHA 解決が HEAD の第一親を参照するため、実用上の下限を `2` とする。この下限に対するバリデーションは実装しない (呼び出し側の責務とする) 。
 
 ### REQ-C-002: push トリガー対象ブランチ
 
@@ -252,7 +269,7 @@ push トリガーは `main` ブランチのみを対象とする。feature ブ�
 
 ### REQ-C-003: paths フィルター
 
-push / pull_request トリガーともに `paths: ['**/*.md']` フィルターを設定し、Markdown 以外の変更では lint ジョブを起動しない。
+push/pull_request トリガーともに `paths: ['**/*.md']` フィルターを設定し、Markdown 以外の変更では lint ジョブを起動しない。
 
 ### REQ-C-004: 使用するすべての Action の SHA 固定
 
@@ -347,3 +364,4 @@ Scenario: lint エラーでワークフローが失敗する
 | 2026-06-22 | 1.0.4   | REQ-C-004 をすべての Action の SHA 固定に拡張 (DR-07 追加)                                                        |
 | 2026-06-22 | 1.0.5   | REQ-F-006 に削除済みファイルの caller 側スキップ処理を追加 (AC-014 追加)                                          |
 | 2026-06-22 | 1.0.6   | Assumptions に初回 push 時の空ツリー SHA フォールバック動作を明記 (ca-get-changed-files が自動処理)               |
+| 2026-08-07 | 1.0.7   | REQ-C-001 を fetch-depth 固定からデフォルト `0` + 入力パラメータによる上書き許容に緩和                            |

--- a/docs/.deckrd/workflows/lint-article/specifications/specifications.md
+++ b/docs/.deckrd/workflows/lint-article/specifications/specifications.md
@@ -1,8 +1,8 @@
 ---
 title: "Design Specification: ci-lint-articles Composite Action Migration"
-based-on: requirements.md v1.0.6
+based-on: requirements.md v1.0.7
 status: Draft
-version: 1.0.5
+version: 1.0.7
 created: "2026-06-22"
 ---
 
@@ -27,7 +27,7 @@ created: "2026-06-22"
 
 本仕様は以下の振る舞いを対象とする。
 
-- push / pull_request / workflow_dispatch の各トリガーに対する lint ジョブの起動条件
+- push/pull_request/workflow_dispatch/workflow_call の各トリガーに対する lint ジョブの起動条件
 - 変更ファイルの取得と SHA 解決ロジック
 - lint 実行の前提条件と実行順序
 - count==0 スキップ・削除済みファイルスキップの振る舞い
@@ -48,9 +48,11 @@ lint ロジックはワークフロー内に直接埋め込まず、外部 actio
 
 ### 2.2 Design Assumptions
 
-- `ca-get-changed-files` は before-sha / after-sha が空文字の場合、イベント種別 (push / pull_request) から自動的に SHA を解決する
+- `ca-get-changed-files` は before-sha/after-sha が **両方とも** 空文字で、かつ `github.event_name` が `push` または `pull_request` の **場合に限り** 自動的に SHA を解決する。以下の 2 点に注意する
+  - 片方だけ空文字だと `before-sha and after-sha must both be specified or both be empty` で失敗する
+  - `push` / `pull_request` 以外のイベント（`workflow_call` 経由の `schedule` / `release` 等を含む）で空文字を渡すと `Unsupported event` で失敗する。そのため caller 側が自前で SHA を解決する必要がある (R-002e)
 - `ca-get-changed-files` は before-sha がオールゼロ (初回 push・新規ブランチ) の場合、自動的に空ツリー SHA にフォールバックしてリポジトリ全ファイルとの差分を返す。caller 側での特別処理は不要
-- `ca-setup-repo` (repo: `aglabo/agla-doc-tools`、ref: commit SHA 固定) は Node.js / pnpm のセットアップと `pnpm install` まで行う。別途インストールステップは不要
+- `ca-setup-repo` (repo: `aglabo/agla-doc-tools`、ref: commit SHA 固定) は Node.js/pnpm のセットアップと `pnpm install` まで行う。別途インストールステップは不要
 - `ca-get-changed-files` の `outputs.files` は改行区切りのファイルパスリストである
 - `markdownlint-cli2` は `ca-setup-repo` によってセットアップされた環境で利用可能になる
 - `outputs.files` のファイルパスリストは、lint 実行ステップ内でシェルスクリプトによりダブルクォートとスペース区切りで展開して lint ツールに渡す
@@ -75,12 +77,13 @@ lint ロジックはワークフロー内に直接埋め込まず、外部 actio
 #### Unit Interaction Map
 
 ```text
-[trigger: push / pull_request / workflow_dispatch]
+[trigger: push / pull_request / workflow_dispatch / workflow_call]
         |
         v
 +---------------------------+
 | actions/checkout          |
-| (fetch-depth: 0)          |
+| (fetch-depth: env,        |
+|  default 0)               |
 +---------------------------+
         |
         v
@@ -93,10 +96,10 @@ lint ロジックはワークフロー内に直接埋め込まず、外部 actio
         v
 +---------------------------+
 | SHA resolve               |
-|  dispatch + HEAD^1 OK  -> before=HEAD^1, after=HEAD    |
-|  dispatch + HEAD^1 NG  -> warning, skip (exit 0)       |
-|  dispatch + other err  -> error (exit non-zero)        |
-|  push / PR             -> before="", after=""          |
+|  push / PR          -> before="", after="" (上流が解決) |
+|  other + parent OK  -> before=parent, after=HEAD        |
+|  other + no parent  -> shallow? error : warning+skip    |
+|  git failure        -> error (exit non-zero)            |
 +---------------------------+
         |
         v
@@ -133,7 +136,7 @@ lint ロジックはワークフロー内に直接埋め込まず、外部 actio
 [GitHub Event]
       |
       v
-[actions/checkout fetch-depth:0]
+[actions/checkout fetch-depth:${FETCH_DEPTH} (default 0)]
       |
       v
 [ca-validate-environment actions-type:read]
@@ -141,10 +144,12 @@ lint ロジックはワークフロー内に直接埋め込まず、外部 actio
       v
 [Resolve before-sha / after-sha]
       |
-      +-- dispatch + HEAD^1 OK  --> before=HEAD^1, after=HEAD
-      +-- dispatch + HEAD^1 NG  --> [warning log, exit 0]
-      +-- dispatch + other err  --> [error log, exit non-zero]
-      +-- push / PR             --> before="", after=""
+      +-- push / PR              --> before="", after="" (上流が自動解決)
+      +-- other + parent OK      --> before=parent, after=HEAD
+      +-- other + no parent      --> [--is-shallow-repository?]
+      |                                +-- false --> [warning log, skip=true, exit 0]
+      |                                +-- true  --> [error log, exit non-zero]
+      +-- git command failure    --> [error log, exit non-zero]
       |
       v
 [ca-get-changed-files pattern:**/*.md]
@@ -181,20 +186,22 @@ lint ロジックはワークフロー内に直接埋め込まず、外部 actio
 
 > **Derivation**: REQUIREMENTS の "Out of Scope" セクションから導出。
 
-- reusable workflow (`ru-*`) の作成
+- reusable workflow (`ru-*`) の新規作成 (`ci-lint-articles.yaml` の `workflow_call` は `fetch-depth` パラメータの受け渡しのみを目的とし、汎用の再利用インターフェースとしては提供しない)
 - 他のワークフローファイルの変更
 - textlint・markdownlint の設定変更
 - lint ルールの追加・変更
 
 ### 2.5 Behavioral Design Decisions
 
-| ID    | Decision                                                                                                                           | Rationale                                                                                                | Affected Rules               | Status |
-| ----- | ---------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ---------------------------- | ------ |
-| DD-01 | composite actions を step-level で直接呼び出す (job-level reusable workflow は使わない)                                            | lint ロジックの保守性を高め、共通基盤の恩恵を受けるため (DR-01)                                          | R-002a〜R-002d, R-003, R-004 | Active |
-| DD-02 | workflow_dispatch 時は `git rev-parse HEAD^1` / `HEAD` でSHAを解決し環境変数にセット、他イベントは空文字                           | `github.sha^1` expression は YAML では直接使用できないため                                               | R-002                        | Active |
-| DD-03 | lint は `textlint --config configs/textlintrc.yaml` と `markdownlint-cli2 --config configs/.markdownlint-cli2.yaml` を直接呼び出す | `pnpm run lint:markdown` は `XDG_CONFIG_HOME` に依存するため除外。`run-textlint.sh` ラッパーを経由しない | R-005                        | Active |
-| DD-04 | 削除済みファイルの除外は caller (ワークフロー) 側の責務とする                                                                      | `ca-get-changed-files` の責務範囲を超えないため (DR-04)                                                  | R-005                        | Active |
-| DD-05 | 使用するすべての Action を commit SHA で固定する                                                                                   | サプライチェーンリスク対策 (DR-07)                                                                       | 全ルール                     | Active |
+| ID    | Decision                                                                                                                               | Rationale                                                                                                                                     | Affected Rules               | Status |
+| ----- | -------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ------ |
+| DD-01 | composite actions を step-level で直接呼び出す (job-level reusable workflow は使わない)                                                | lint ロジックの保守性を高め、共通基盤の恩恵を受けるため (DR-01)                                                                               | R-002a〜R-002d, R-003, R-004 | Active |
+| DD-02 | `push` / `pull_request` は空文字で上流に委譲し、それ以外のイベントは `git rev-list --parents` で SHA を解決して `GITHUB_OUTPUT` へ出力 | `github.sha^1` expression は YAML では直接使用できない。また上流の自動解決は push/PR のみ対応のため、他イベントは caller が解決する必要がある | R-002                        | Active |
+| DD-04 | ステップ間の SHA 受け渡しは `GITHUB_ENV` + `${{ env.X }}` ではなく `GITHUB_OUTPUT` + `${{ steps.<id>.outputs.<key> }}` を使う          | 実行時生成の env は静的解析で追えず VS Code の GitHub Actions 拡張が誤検知する。上流 `ca-get-changed-files` も outputs 方式                   | R-002, R-004                 | Active |
+| DD-05 | 親コミットが見えない場合、`git rev-parse --is-shallow-repository` で初回コミットと shallow clone を切り分け、shallow は失敗させる      | shallow を初回コミットと誤認して skip すると lint が実行されないまま成功扱いになるため (fail-first)                                           | R-002b, R-002f               | Active |
+| DD-03 | lint は `textlint --config configs/textlintrc.yaml` と `markdownlint-cli2 --config configs/.markdownlint-cli2.yaml` を直接呼び出す     | `pnpm run lint:markdown` は `XDG_CONFIG_HOME` に依存するため除外。`run-textlint.sh` ラッパーを経由しない                                      | R-005                        | Active |
+| DD-04 | 削除済みファイルの除外は caller (ワークフロー) 側の責務とする                                                                          | `ca-get-changed-files` の責務範囲を超えないため (DR-04)                                                                                       | R-005                        | Active |
+| DD-05 | 使用するすべての Action を commit SHA で固定する                                                                                       | サプライチェーンリスク対策 (DR-07)                                                                                                            | 全ルール                     | Active |
 
 ### 2.6 Related Decision Records
 
@@ -225,16 +232,24 @@ lint ロジックはワークフロー内に直接埋め込まず、外部 actio
 
 ### 3.1 Input Domain
 
-- トリガー: `push` (main ブランチ、`paths: ['**/*.md']`) 、`pull_request` (main ブランチ、`paths: ['**/*.md']`) 、`workflow_dispatch`
+- トリガー: `push` (main ブランチ、`paths: ['**/*.md']`) 、`pull_request` (main ブランチ、`paths: ['**/*.md']`) 、`workflow_dispatch`、`workflow_call`
+- 入力パラメータ:
+
+  | Name          | Type     | Required | Default | Applies to                            | Description                          |
+  | ------------- | -------- | -------- | ------- | ------------------------------------- | ------------------------------------ |
+  | `fetch-depth` | `string` | No       | `"0"`   | `workflow_dispatch` / `workflow_call` | checkout の fetch-depth (0 = 全履歴) |
+
 - ステップ実行順序 (この順序で実行しなければならない。順序の変更は禁止する):
-  1. `actions/checkout` (fetch-depth: 0)
+  1. `actions/checkout` (fetch-depth: ジョブレベル `env.FETCH_DEPTH`)
   2. `ca-validate-environment` (actions-type: read)
-  3. SHA 解決 (トリガー種別に応じて before-sha / after-sha を決定)
+  3. SHA 解決 (トリガー種別に応じて before-sha/after-sha を決定)
   4. `ca-get-changed-files` (pattern: `**/*.md`)
   5. `ca-setup-repo` (repo: `aglabo/agla-doc-tools`、ref: commit SHA 固定)
   6. lint 実行
 - 前提条件:
-  - `actions/checkout` は `fetch-depth: 0` で実行しなければならない (MUST) 。`fetch-depth: 1` またはデフォルト値を使用してはならない
+  - `fetch-depth` はジョブレベルの `env.FETCH_DEPTH` に一度だけ解決し、`actions/checkout` はその env を参照しなければならない (MUST) 。`with:` に `inputs` を直接展開してはならない
+  - `env.FETCH_DEPTH` は `${{ inputs.fetch-depth || '0' }}` で解決しなければならない (MUST) 。`inputs` コンテキストは `push` / `pull_request` では未定義であり、トリガー配下の `default` は適用されないため、`|| '0'` フォールバックを省略すると空文字となり全履歴が取得されない
+  - `fetch-depth` 未指定時は `0` (全履歴) に解決されなければならない (MUST)
   - `ca-validate-environment` は `actions/checkout` の直後、他のいかなるステップより前に実行しなければならない (MUST)
   - `ca-setup-repo` の `ref` は commit SHA で固定しなければならない (MUST) 。ブランチ名・可変タグの使用は禁止する
   - すべての Action が commit SHA で固定されていること
@@ -271,12 +286,20 @@ Rule IDs are referenced in Traceability and Edge Cases.
 
 ### R-002: SHA 解決ルール
 
-| Rule ID | Step | Condition                                                                          | Outcome                                                                     |
-| ------- | ---: | ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| R-002a  |    1 | `workflow_dispatch` イベント、かつ `git rev-parse HEAD^1` が成功する               | `HEAD^1` を before-sha、`HEAD` を after-sha として環境変数にセット          |
-| R-002b  |    2 | `workflow_dispatch` イベント、かつ `HEAD^1` が存在しない (リポジトリの最初の push) | warning ログを出力して lint をスキップし exit 0                             |
-| R-002c  |    3 | `workflow_dispatch` イベント、かつ `git rev-parse` がその他の理由で失敗する        | エラーログを出力してジョブを失敗させる (exit non-zero)                      |
-| R-002d  |    4 | `push` または `pull_request` イベント                                              | before-sha / after-sha を空文字にセット (`ca-get-changed-files` が自動解決) |
+分岐は `push` / `pull_request` に該当するイベントかどうかで決まる。判定順は R-002d → R-002a/b/c/f とする。
+
+| Rule ID | Step | Condition                                                                                                    | Outcome                                                                                         |
+| ------- | ---: | ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| R-002d  |    1 | `push` または `pull_request` イベント                                                                        | `before_sha` / `after_sha` の両方を空文字で出力 (`ca-get-changed-files` が自動解決)             |
+| R-002a  |    2 | 上記以外のイベント、かつ `git rev-list --parents -n 1 HEAD` が親を返す                                       | 第2フィールド (親) を `before_sha`、第1フィールド (HEAD) を `after_sha` として GITHUB_OUTPUT へ |
+| R-002b  |    3 | 上記以外のイベント、親が存在せず、かつ `git rev-parse --is-shallow-repository` が `false` (真の初回コミット) | warning ログを出力して `skip=true` を出力し exit 0                                              |
+| R-002f  |    4 | 上記以外のイベント、親が存在せず、かつ `--is-shallow-repository` が `true` (shallow clone)                   | error ログを出力してジョブを失敗させる (exit non-zero)。黙ってスキップしない                    |
+| R-002c  |    5 | `git` コマンドがその他の理由で失敗する                                                                       | エラーログを出力してジョブを失敗させる (exit non-zero)                                          |
+| R-002e  |    — | `workflow_call` 経由で `schedule` / `release` 等から呼ばれた場合                                             | R-002a/b/f と同じ自前解決経路を通る。空文字を渡すと上流が `Unsupported event` で失敗するため    |
+
+R-002f の根拠: 親フィールドが 1 つしかない状態は「真の初回コミット」と「shallow clone で親が未 fetch」の 2 通りがある。`fetch-depth` は `workflow_call` の caller が `"1"` を渡せるため後者は現実に起こりうる。これを初回コミットと誤認して skip すると、リントが実行されないまま成功扱いになる。
+
+R-002f の適用範囲: この判定が働くのは caller 側で SHA を解決する非 push/PR 経路に限られる。`push` / `pull_request` (`workflow_call` の親が push の場合を含む) では空文字を渡すため上流が SHA を解決する。この経路で shallow により base へ到達できない場合、上流の `git diff` が `fatal: bad object` を出力し終了コード 128 で失敗する。メッセージの明快さは R-002f に劣るものの、いずれの経路でもリントを黙ってスキップすることはない。
 
 ### R-003: 環境検証
 
@@ -312,16 +335,19 @@ Rule IDs are referenced in Traceability and Edge Cases.
 
 ## 5. Edge Cases
 
-| Input / Condition                                         | 振る舞い                                                     | REQ           | Rationale                                                |
-| --------------------------------------------------------- | ------------------------------------------------------------ | ------------- | -------------------------------------------------------- |
-| 初回 push (before-sha がオールゼロ)                       | `ca-get-changed-files` が空ツリーとの diff にフォールバック  | REQ-F-004     | caller 側処理不要。リポジトリ全ファイルが対象になる      |
-| `outputs.count` が 0                                      | lint をスキップし warning ログを出力して exit 0              | REQ-F-006     | 変更ファイルなし = lint 不要。エラーにしない             |
-| 変更ファイルに削除済みファイルが含まれる                  | 存在チェックで除外し "deleted → skip" をログに出力           | REQ-F-006     | 存在しないファイルを lint ツールに渡すとエラーになるため |
-| `*.md` 以外の変更のみを含む push / PR                     | lint ジョブ自体が起動しない (paths フィルター)               | REQ-F-001/002 | GitHub Actions の `paths` フィルターで制御               |
-| workflow_dispatch で main ブランチ以外から実行            | lint ジョブは起動する (workflow_dispatch は branch 制約なし) | REQ-F-007     | 手動実行はどのブランチからでも可能                       |
-| workflow_dispatch で HEAD^1 が存在しない (最初のコミット) | warning ログを出力して lint をスキップし exit 0              | REQ-F-007     | 比較対象がないため lint 不要。エラーにしない             |
-| 変更ファイルがすべて削除済み (count > 0 だが全件スキップ) | 全ファイルを "deleted → skip" でスキップし exit 0            | REQ-F-006     | lint 対象ファイルが残らない = lint 不要。エラーにしない  |
-| textlint はエラーあり                                     | textlint 失敗で即終了 (後続の lint ステップを実行しない)     | REQ-F-006     | fail-fast はツール単位。エラー詳細はローカルで確認       |
+| Input / Condition                                            | 振る舞い                                                     | REQ           | Rationale                                                                                    |
+| ------------------------------------------------------------ | ------------------------------------------------------------ | ------------- | -------------------------------------------------------------------------------------------- |
+| 初回 push (before-sha がオールゼロ)                          | `ca-get-changed-files` が空ツリーとの diff にフォールバック  | REQ-F-004     | caller 側処理不要。リポジトリ全ファイルが対象になる                                          |
+| `outputs.count` が 0                                         | lint をスキップし warning ログを出力して exit 0              | REQ-F-006     | 変更ファイルなし = lint 不要。エラーにしない                                                 |
+| 変更ファイルに削除済みファイルが含まれる                     | 存在チェックで除外し "deleted → skip" をログに出力           | REQ-F-006     | 存在しないファイルを lint ツールに渡すとエラーになるため                                     |
+| `*.md` 以外の変更のみを含む push / PR                        | lint ジョブ自体が起動しない (paths フィルター)               | REQ-F-001/002 | GitHub Actions の `paths` フィルターで制御                                                   |
+| workflow_dispatch で main ブランチ以外から実行               | lint ジョブは起動する (workflow_dispatch は branch 制約なし) | REQ-F-007     | 手動実行はどのブランチからでも可能                                                           |
+| 非 push/PR イベントで親コミットが存在しない (最初のコミット) | warning ログを出力して lint をスキップし exit 0              | REQ-F-007     | 比較対象がないため lint 不要。エラーにしない                                                 |
+| shallow clone で親が未 fetch (非 push/PR、fetch-depth: 1 等) | error ログを出力してジョブを失敗させる (exit non-zero)       | REQ-F-007     | 初回コミットと誤認して skip するとリントが黙って実行されないまま成功扱いになるため           |
+| shallow clone で base に到達不可 (push / PR)                 | 上流の `git diff` が `fatal: bad object` で失敗 (exit 128)   | REQ-F-004     | 空文字を渡す経路のため caller 側の判定は働かない。ただし失敗するのでスキップ扱いにはならない |
+| `workflow_call` 経由で schedule / release 等から呼ばれる     | caller 側 (resolve-sha) が自前で SHA を解決する              | REQ-F-007     | 空文字を渡すと上流が `Unsupported event` で失敗するため                                      |
+| 変更ファイルがすべて削除済み (count > 0 だが全件スキップ)    | 全ファイルを "deleted → skip" でスキップし exit 0            | REQ-F-006     | lint 対象ファイルが残らない = lint 不要。エラーにしない                                      |
+| textlint はエラーあり                                        | textlint 失敗で即終了 (後続の lint ステップを実行しない)     | REQ-F-006     | fail-fast はツール単位。エラー詳細はローカルで確認                                           |
 
 ---
 
@@ -338,7 +364,7 @@ Rule IDs are referenced in Traceability and Edge Cases.
 | REQ-F-007      | R-001c, R-002a, R-002b, R-002c | workflow_dispatch トリガー + SHA 解決 (スキップ・エラー含む) |
 | REQ-NF-001     | Section 2.1                    | composite actions 呼び出し中心の構成                         |
 | REQ-NF-002     | Section 2.2 Assumptions        | 外部リポジトリからの composite actions 参照                  |
-| REQ-C-001      | Section 3.1 前提条件           | fetch-depth: 0 は checkout の前提条件                        |
+| REQ-C-001      | Section 3.1 入力パラメータ     | fetch-depth はデフォルト 0、パラメータで上書き可             |
 | REQ-C-002      | R-001a                         | push トリガーは main ブランチのみ                            |
 | REQ-C-003      | R-001a, R-001b                 | paths フィルター `**/*.md`                                   |
 | REQ-C-004      | Section 3.1 Input Domain       | 全 Action を commit SHA で固定                               |
@@ -350,20 +376,22 @@ Rule IDs are referenced in Traceability and Edge Cases.
 
 > **Status**: INCOMPLETE (REQ-C-005 の前提条件が未解決)
 
-| # | Question                                                                                        | Source    | Impact                                                                      |
-| - | ----------------------------------------------------------------------------------------------- | --------- | --------------------------------------------------------------------------- |
-| 1 | `ca-get-changed-files` の SHA 指定優先動作 (DR-04) が `aglabo/ci-platform` に実装済みか         | REQ-C-005 | 未実装の場合、`ci-lint-articles.yaml` の実装前に ci-platform 側の対応が必要 |
-| 2 | `ca-validate-environment`、`ca-get-changed-files`、`ca-setup-repo` の step-level 呼び出し用 SHA | REQ-C-004 | 実装時に各 composite action の最新 commit SHA を確定する必要がある          |
+| # | Question                                                                                                       | Source    | Impact                                                                                                      |
+| - | -------------------------------------------------------------------------------------------------------------- | --------- | ----------------------------------------------------------------------------------------------------------- |
+| 1 | `ca-get-changed-files` の SHA 指定優先動作 (DR-04) が `aglabo/ci-platform` に実装済みか                        | REQ-C-005 | 未実装の場合、`ci-lint-articles.yaml` の実装前に ci-platform 側の対応が必要                                 |
+| 2 | ~~`ca-validate-environment`、`ca-get-changed-files`、`ca-setup-repo` の step-level 呼び出し用 SHA~~ (解決済み) | REQ-C-004 | 解決済み。3 Action とも `aglabo/ci-platform` v0.3.3 (`9cc4b15bf10854ecc0fc2ea0a419d96566ea8bde`) に固定した |
 
 ---
 
 ## 8. Change History
 
-| Date       | Version | Description                                                                                                                                                                                                  |
-| ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 2026-06-22 | 1.0.0   | Initial specification                                                                                                                                                                                        |
-| 2026-06-22 | 1.0.1   | Codex review 対応: HEAD^1 なし時の warning スキップ追加 (R-002b) 、fail-fast 明記 (R-005e/f) 、パス展開安全性を Assumptions に追記                                                                           |
-| 2026-06-22 | 1.0.2   | explore review 対応: ステップ実行順序を Section 3.1 に明記、R-002c (git rev-parse その他エラー → exit non-zero) 追加、図を更新、REQ-F-007 トレーサビリティに R-002b/c 追記                                   |
-| 2026-06-22 | 1.0.3   | harden review 対応: ca-setup-tool → ca-setup-repo に統一、ステップ順序 MUST 化、fetch-depth MUST 追記、ca-setup-repo の ref commit SHA 固定 MUST 追記、R-005f を「後続の lint ステップを実行しない」に明確化 |
-| 2026-06-22 | 1.0.4   | fix review 対応: フロントマター version 修正、DD-01 Affected Rules 修正、R-003 条件文を Section 3.1 に統一、REQ-C-001 参照修正、R-005b 参照範囲を R-005c〜R-005f に修正                                      |
-| 2026-06-22 | 1.0.5   | Codex review 対応: ファイルパス特殊文字制約を Assumptions に追記、fail-fast をツール単位と明記、全削除済みシナリオを Edge Cases に追加                                                                       |
+| Date       | Version | Description                                                                                                                                                                                                                                        |
+| ---------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-06-22 | 1.0.0   | Initial specification                                                                                                                                                                                                                              |
+| 2026-06-22 | 1.0.1   | Codex review 対応: HEAD^1 なし時の warning スキップ追加 (R-002b) 、fail-fast 明記 (R-005e/f) 、パス展開安全性を Assumptions に追記                                                                                                                 |
+| 2026-06-22 | 1.0.2   | explore review 対応: ステップ実行順序を Section 3.1 に明記、R-002c (git rev-parse その他エラー → exit non-zero) 追加、図を更新、REQ-F-007 トレーサビリティに R-002b/c 追記                                                                         |
+| 2026-06-22 | 1.0.3   | harden review 対応: ca-setup-tool → ca-setup-repo に統一、ステップ順序 MUST 化、fetch-depth MUST 追記、ca-setup-repo の ref commit SHA 固定 MUST 追記、R-005f を「後続の lint ステップを実行しない」に明確化                                       |
+| 2026-06-22 | 1.0.4   | fix review 対応: フロントマター version 修正、DD-01 Affected Rules 修正、R-003 条件文を Section 3.1 に統一、REQ-C-001 参照修正、R-005b 参照範囲を R-005c〜R-005f に修正                                                                            |
+| 2026-06-22 | 1.0.5   | Codex review 対応: ファイルパス特殊文字制約を Assumptions に追記、fail-fast をツール単位と明記、全削除済みシナリオを Edge Cases に追加                                                                                                             |
+| 2026-08-07 | 1.0.6   | fetch-depth をパラメータ化: Section 3.1 に入力パラメータ表と env.FETCH_DEPTH 経由の解決を追加、fetch-depth MUST をデフォルト 0 に緩和、図を更新                                                                                                    |
+| 2026-08-07 | 1.0.7   | R-002 を全面改訂: 分岐を push/PR か否かに反転、SHA 受け渡しを GITHUB_OUTPUT へ移行 (DD-04) 、workflow_call 由来の非 push/PR イベントに対応 (R-002e) 、shallow clone を初回コミットと誤認しない判定を追加 (R-002f / DD-05) 、図と Edge Cases を更新 |

--- a/docs/.deckrd/workflows/lint-article/tasks/tasks.md
+++ b/docs/.deckrd/workflows/lint-article/tasks/tasks.md
@@ -39,8 +39,8 @@ source: specifications.md
   - Scenario: Given checkout ステップが定義されている
   - Expected: Then `with.persist-credentials: false` が設定されていなければならない (MUST)
 
-- [x] **T-00-01-03**: skip 伝播の `if` 条件が changed-files / setup-repo / lint の 3 ステップに付与されている
-  - Target: `ci-lint-articles.yaml` の changed-files / setup-repo / lint 各ステップ
+- [x] **T-00-01-03**: skip 伝播の `if` 条件が changed-files/setup-repo/lint の 3 ステップに付与されている
+  - Target: `ci-lint-articles.yaml` の changed-files/setup-repo/lint 各ステップ
   - Scenario: Given resolve-sha ステップが `skip=true` を出力した
   - Expected: Then 3 ステップそれぞれに `if: steps.resolve-sha.outputs.skip != 'true'` が定義されていなければならない (MUST)
 
@@ -52,19 +52,19 @@ source: specifications.md
 
 - [x] **T-00-02-02**: `ca-validate-environment` が commit SHA で固定されている
   - Target: `ci-lint-articles.yaml` の validate-env ステップ
-  - Expected: Then `uses: aglabo/ci-platform/.github/actions/ca-validate-environment@8d63776a598f98913915e57b74e63ba5d06d5a47` が定義されていなければならない (MUST)
+  - Expected: Then `uses: aglabo/ci-platform/.github/actions/ca-validate-environment@9cc4b15bf10854ecc0fc2ea0a419d96566ea8bde` が定義されていなければならない (MUST)
 
 - [x] **T-00-02-03**: `ca-get-changed-files` が commit SHA で固定されている
   - Target: `ci-lint-articles.yaml` の changed-files ステップ
-  - Expected: Then `uses: aglabo/ci-platform/.github/actions/ca-get-changed-files@8d63776a598f98913915e57b74e63ba5d06d5a47` が定義されていなければならない (MUST)
+  - Expected: Then `uses: aglabo/ci-platform/.github/actions/ca-get-changed-files@9cc4b15bf10854ecc0fc2ea0a419d96566ea8bde` が定義されていなければならない (MUST)
 
 - [x] **T-00-02-04**: `ca-setup-repo` が commit SHA で固定されている
   - Target: `ci-lint-articles.yaml` の setup-repo ステップ
-  - Expected: Then `uses: aglabo/ci-platform/.github/actions/ca-setup-repo@8d63776a598f98913915e57b74e63ba5d06d5a47` が定義されていなければならない (MUST)
+  - Expected: Then `uses: aglabo/ci-platform/.github/actions/ca-setup-repo@9cc4b15bf10854ecc0fc2ea0a419d96566ea8bde` が定義されていなければならない (MUST)
 
 - [x] **T-00-02-05**: `agla-doc-tools` の `ref` が commit SHA で固定されている
   - Target: `ci-lint-articles.yaml` の setup-repo ステップ `with.ref`
-  - Expected: Then `ref: bec772fc1d22fbf43fd57ef3a71f7972b83b3e24 # v0.1.1` が定義されていなければならない (MUST)
+  - Expected: Then `ref: 65055a58be00ace993489273fe2a037d1ec1468d # v0.2.0` が定義されていなければならない (MUST)
 
 ---
 
@@ -106,20 +106,30 @@ source: specifications.md
 
 #### T-02-01: workflow_dispatch で親コミットあり
 
-- [x] **T-02-01-01**: workflow_dispatch で HEAD^1 が取得でき GITHUB_ENV に書き込まれる
+- [x] **T-02-01-01**: workflow_dispatch で HEAD の親が取得でき GITHUB_OUTPUT に書き込まれる
   - Target: `resolve-sha` ステップのシェルスクリプト
   - Scenario: Given `workflow_dispatch` イベント、かつ `git rev-list --parents -n 1 HEAD` が 2 フィールド以上を返す (親あり)
-  - Expected: Then `BEFORE_SHA=<HEAD^1>`, `AFTER_SHA=<HEAD>` が `GITHUB_ENV` に書き込まれ、
+  - Expected: Then `before_sha=<親>`, `after_sha=<HEAD>` が `GITHUB_OUTPUT` に書き込まれ、
     `skip=false` が `GITHUB_OUTPUT` に書き込まれなければならない (MUST) 。
-    また `changed-files` ステップの `with.before-sha: ${{ env.BEFORE_SHA }}` / `with.after-sha: ${{ env.AFTER_SHA }}` が
+    また `changed-files` ステップの
+    `with.before-sha: ${{ steps.resolve-sha.outputs.before_sha }}`/`with.after-sha: ${{ steps.resolve-sha.outputs.after_sha }}` が
     YAML に定義されていなければならない (MUST)
 
 #### T-02-02: push / pull_request では空文字 SHA を設定
 
-- [x] **T-02-02-01**: push / PR 時は BEFORE_SHA / AFTER_SHA が空文字で GITHUB_ENV に書き込まれる
+- [x] **T-02-02-01**: push/PR 時は before_sha/after_sha が空文字で GITHUB_OUTPUT に書き込まれる
   - Target: `resolve-sha` ステップのシェルスクリプト
   - Scenario: Given `push` または `pull_request` イベント
-  - Expected: Then `BEFORE_SHA=""`, `AFTER_SHA=""` が `GITHUB_ENV` に書き込まれ、`skip=false` が `GITHUB_OUTPUT` に書き込まれなければならない (MUST)
+  - Expected: Then `before_sha=`, `after_sha=` が **両方とも空文字で** `GITHUB_OUTPUT` に書き込まれ、`skip=false` が `GITHUB_OUTPUT` に書き込まれなければならない (MUST) 。
+    片方だけ空だと上流が `before-sha and after-sha must both be specified or both be empty` で失敗するため、行完全一致で検証すること
+
+#### T-02-05: workflow_call 由来の非 push/PR イベント
+
+- [x] **T-02-05-01**: schedule 等の非 push/PR イベントでも自前で SHA を解決する
+  - Target: `resolve-sha` ステップのシェルスクリプト
+  - Scenario: Given `schedule` など `push`/`pull_request`/`workflow_dispatch` 以外のイベント、かつ親コミットが存在する
+  - Expected: Then `before_sha=<親>`, `after_sha=<HEAD>` が実 SHA で `GITHUB_OUTPUT` に書き込まれなければならない (MUST) 。
+    空文字を渡すと上流 `ca-get-changed-files` が `Unsupported event` で失敗するため
 
 ### [異常] Error Cases
 
@@ -136,9 +146,21 @@ source: specifications.md
 
 - [x] **T-02-04-01**: 初回コミット (parent 数 == 0) の場合、warning を出力して後続ステップをスキップする
   - Target: `resolve-sha` ステップのシェルスクリプト
-  - Scenario: Given `workflow_dispatch` イベント、かつ `git rev-list --parents -n 1 HEAD` が 1 フィールド (親なし) を返す
+  - Scenario: Given 非 push/PR イベント、`git rev-list --parents -n 1 HEAD` が 1 フィールド (親なし) を返し、
+    かつ `git rev-parse --is-shallow-repository` が `false` (真の初回コミット) を返す
   - Expected: Then `skip=true` が `GITHUB_OUTPUT` に書き込まれ、warning ログが出力され、exit 0 となる。
-    後続の `changed-files` / `setup-repo` / `lint` ステップは `if: steps.resolve-sha.outputs.skip != 'true'` により実行されない
+    後続の `changed-files`/`setup-repo`/`lint` ステップは `if: steps.resolve-sha.outputs.skip != 'true'` により実行されない
+
+#### T-02-06: shallow clone で親が未 fetch
+
+- [x] **T-02-06-01**: shallow clone を初回コミットと誤認せず、ジョブを失敗させる
+  - Target: `resolve-sha` ステップのシェルスクリプト
+  - Scenario: Given 非 push/PR イベント、`git rev-list --parents -n 1 HEAD` が 1 フィールド (親なし) を返し、
+    かつ `git rev-parse --is-shallow-repository` が `true` を返す
+  - Expected: Then error ログを出力し、exit non-zero でジョブを失敗させなければならない (MUST) 。
+    `skip=true` を書き込んではならない (MUST NOT) 。
+    `workflow_call` の caller は `fetch-depth: "1"` を渡せるため shallow は現実に起こりうる。
+    これを skip すると lint が実行されないまま成功扱いになる (fail-first 原則)
 
 ---
 
@@ -152,15 +174,16 @@ source: specifications.md
   - Target: `ci-lint-articles.yaml` のステップ順序
   - Scenario: Given ワークフローが起動する、When ステップ定義を確認する
   - Expected: Then `validate-env` ステップが YAML のステップリスト上で `checkout` の直後 (2 番目) に定義されていなければならない (MUST) 。
-    `resolve-sha` より前に配置されていること。また `checkout` の `fetch-depth: 0` が定義されていなければならない (MUST)
+    `resolve-sha` より前に配置されていること。また `checkout` の `fetch-depth` がジョブレベルの `env.FETCH_DEPTH` を参照し、
+    未指定時に `0` へ解決されなければならない (MUST)
 
 #### T-03-02: ca-get-changed-files で変更 *.md を取得
 
-- [x] **T-03-02-01**: changed-files ステップが BEFORE_SHA / AFTER_SHA を渡して実行される
+- [x] **T-03-02-01**: changed-files ステップが BEFORE_SHA/AFTER_SHA を渡して実行される
   - Target: `changed-files` ステップの with パラメータ
-  - Scenario: Given `resolve-sha` が完了し `GITHUB_ENV` に SHA が設定済み、When `changed-files` ステップが実行される
-  - Expected: Then `ca-get-changed-files` に `pattern: '**/*.md'`、`before-sha: ${{ env.BEFORE_SHA }}`、
-    `after-sha: ${{ env.AFTER_SHA }}` が渡されなければならない (MUST)
+  - Scenario: Given `resolve-sha` が完了し `GITHUB_OUTPUT` に SHA が設定済み、When `changed-files` ステップが実行される
+  - Expected: Then `ca-get-changed-files` に `pattern: '**/*.md'`、`before-sha: ${{ steps.resolve-sha.outputs.before_sha }}`、
+    `after-sha: ${{ steps.resolve-sha.outputs.after_sha }}` が渡されなければならない (MUST)
 
 - [x] **T-03-02-02**: skip=true の場合、changed-files ステップが実行されない
   - Target: `changed-files` ステップの `if:` 条件
@@ -181,7 +204,9 @@ source: specifications.md
 - [x] **T-03-04-01**: ca-setup-repo ステップが正しいパラメータで定義されている
   - Target: `ci-lint-articles.yaml` の `setup-repo` ステップ
   - Scenario: Given ワークフローが定義されている、When setup-repo ステップ定義を確認する
-  - Expected: Then `repo: aglabo/agla-doc-tools`、`path: .tools/agla-doc-tools`、`ref: bec772fc1d22fbf43fd57ef3a71f7972b83b3e24` が定義されていなければならない (MUST)
+  - Expected: Then `repo: aglabo/agla-doc-tools`、`path: .tools/agla-doc-tools`、`ref: 65055a58be00ace993489273fe2a037d1ec1468d` が定義されていなければならない (MUST) 。
+    また `agla-doc-tools` v0.2.0 の `engines` (`node >=24`、`pnpm >=11`) を満たすため、
+    `node-version: "24"` と `pnpm-version: "11"` が定義されていなければならない (MUST)
 
 - [x] **T-03-04-02**: skip=true の場合、setup-repo ステップが実行されない
   - Target: `ci-lint-articles.yaml` の `setup-repo` ステップの `if:` 条件
@@ -256,7 +281,7 @@ source: specifications.md
   - Expected: Then `"deleted -> skip"` がログに出力され、そのファイルへの lint は実行されず次のファイルに進む (exit 0)
 
 - [x] **T-04-03-03**: 全ファイルが削除済みの場合でも exit 0 になる
-  - Target: `lint` ステップのシェルスクリプト (R-005b / R-005c)
+  - Target: `lint` ステップのシェルスクリプト (R-005b/R-005c)
   - Scenario: Given `CHANGED_COUNT` が 1 以上、かつ `outputs.files` に含まれる全ファイルがファイルシステム上に存在しない
   - Expected: Then 全ファイルが `"deleted -> skip"` でスキップされ、lint を一切実行せず exit 0 で完了する
 


### PR DESCRIPTION
## Overview

**Summary**
Pin the `ci-lint-articles` workflow to release-tagged action SHAs and update the lint toolchain to agla-doc-tools v0.2.0.

**Background / Motivation**
The three `ci-platform` composite actions were pinned to a SHA whose comment read `# main`, meaning the reference tracked a moving branch. REQ-C-004 requires every action to be pinned to a commit SHA and forbids branch names or mutable tags, so the reference was moved to the SHA behind release v0.3.3.

The lint toolchain also needed to follow agla-doc-tools v0.2.0. That release declares `engines` of `node >=24` and `pnpm >=11`, while `ca-setup-repo` defaults to node 22 and pnpm 10. Without an explicit override, `pnpm install --frozen-lockfile` fails on an engines violation, so both versions are now passed from the caller.

Finally, `fetch-depth` was set back to `0`. This is not a new decision — it restores behavior the spec already required. See the table under Additional Notes.

## Changes

### Core Changes

- `.github/workflows/ci-lint-articles.yaml`
  - Pin `ca-validate-environment`, `ca-get-changed-files`, and `ca-setup-repo` to `9cc4b15bf10854ecc0fc2ea0a419d96566ea8bde` (v0.3.3), replacing `8d63776a…` (`# main`)
  - Update the `ca-setup-repo` `ref` to `65055a58be00ace993489273fe2a037d1ec1468d` (v0.2.0), replacing `bec772fc…` (v0.1.1)
  - Add `node-version: "24"` and `pnpm-version: "11"` to `ca-setup-repo`
  - Change `actions/checkout` `fetch-depth` from `30` to `0`

### Test Updates

No test changes. This branch touches CI configuration and deckrd documents only; the shellspec suites under `.github/__tests__/` are unaffected.

### Removed

Nothing removed.

### Documentation

- `docs/.deckrd/workflows/lint-article/implementation.md` — update the reference SHA table to v0.3.3 and v0.2.0, and record why `node-version` and `pnpm-version` must be passed explicitly
- `docs/.deckrd/workflows/lint-article/requirements.md` — normalize separator notation (`A / B` to `A/B`)
- `docs/.deckrd/workflows/lint-article/specifications.md` — normalize trigger and SHA-resolution notation, and mark open question 2 (call-site SHAs) as resolved
- `docs/.deckrd/workflows/lint-article/tasks.md` — update expected SHAs to v0.3.3 and v0.2.0, and add the `node-version` / `pnpm-version` requirement to T-03-04-01

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Test
- [x] Documentation
- [ ] Configuration
- [x] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [ ] Tests pass (if test suite exists)
- [x] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Breaking Change

None. The workflow keeps the same triggers, inputs, and outputs. All changes are internal to CI execution.

## Additional Notes

### `fetch-depth` restores the documented requirement

The change from `30` to `0` reverts drift rather than introducing a new rule. Three documents already defined `0` as a MUST:

| Document | Location | Requirement |
| --- | --- | --- |
| `requirements.md` | REQ-C-001 | `ca-get-changed-files` needs full git history, so `fetch-depth` must be `0` |
| `specifications.md` | R-002 (Section 3.1) | Must run with `fetch-depth: 0`; `fetch-depth: 1` and the default value must not be used |
| `tasks.md` | T-02-01 | `checkout` must define `fetch-depth: 0` |

The value `30` was introduced in #171 (`dee2bc7`). With a shallow clone, `ca-get-changed-files` can fail to resolve an older base SHA and may miss changed files.

### Review notes

Code and documentation are updated together in this branch, so the deckrd traceability chain (REQ / SPEC / TASK / IMPL) stays consistent.

Worth verifying on the first CI run: that `pnpm install --frozen-lockfile` completes without an engines violation, and that full history is fetched so changed-file detection behaves correctly.
