### PR TITLE
fix(runners): reject empty runner selections

### DIFF
--- a/runners/__tests__/unit/run-shellspec.unit.spec.sh
+++ b/runners/__tests__/unit/run-shellspec.unit.spec.sh
@@ -1,0 +1,243 @@
+#shellcheck shell=sh
+# runners/__tests__/unit/run-shellspec.unit.spec.sh
+# @(#) : ShellSpec unit tests for runners/run-shellspec.sh
+#
+# Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+# ─── Internal Helpers ──────────────────────────────────────────────────────────
+
+_SCRIPT="${SHELLSPEC_PROJECT_ROOT}/runners/run-shellspec.sh"
+
+# resolve_spec_files is exercised by sourcing run-shellspec.sh rather than by
+# running it. Two reasons:
+#
+#   1. Recursion. This spec file lives under __tests__/unit/, so it is itself
+#      part of the "unit" and "all" sets. Invoking `run-shellspec.sh unit` from
+#      here would rediscover and re-run this very file, without bound.
+#   2. Cost. The type-resolution paths never need shellspec to actually launch;
+#      only the resolved file list and the exit status are under test.
+#
+# run-shellspec.sh guards its main() behind a BASH_SOURCE check, so sourcing it
+# defines the functions without running anything. `set -euo pipefail` leaks in
+# from that source, so every helper below runs in a subshell and relaxes it;
+# otherwise a deliberately failing call would abort shellspec's own shell.
+
+# Runs resolve_spec_files against an isolated fixture tree.
+# The real repository is not used as the search root: its spec inventory shifts
+# as files are added (this file included), which would make any assertion here
+# drift. SPEC_SEARCH_ROOT is read at source time, hence it is set beforehand.
+resolve_in_fixture() {
+  (
+    SPEC_SEARCH_ROOT="$FIXTURE_ROOT"
+    export SPEC_SEARCH_ROOT
+    # shellcheck disable=SC1090
+    . "$_SCRIPT"
+    set +eu
+    resolve_spec_files "$@"
+  )
+}
+
+# Reports the integration gate value after resolving the given test type.
+# Emits the resulting SKIP_INTEGRATION_TESTS on stdout so it can be asserted.
+gate_after_resolve() {
+  (
+    SPEC_SEARCH_ROOT="$FIXTURE_ROOT"
+    SKIP_INTEGRATION_TESTS=1
+    export SPEC_SEARCH_ROOT SKIP_INTEGRATION_TESTS
+    # shellcheck disable=SC1090
+    . "$_SCRIPT"
+    set +eu
+    resolve_spec_files "$@" >/dev/null 2>&1
+    printf '%s\n' "$SKIP_INTEGRATION_TESTS"
+  )
+}
+
+# Fixture tree: one unit spec, and an empty functional directory so that
+# "functional" is a real-but-empty test type rather than a missing one.
+setup_fixture() {
+  FIXTURE_ROOT=$(mktemp -d)
+  export FIXTURE_ROOT
+  mkdir -p "$FIXTURE_ROOT/__tests__/unit" "$FIXTURE_ROOT/__tests__/functional"
+  printf '#shellcheck shell=sh\nDescribe "fixture"\nEnd\n' \
+    > "$FIXTURE_ROOT/__tests__/unit/sample.unit.spec.sh"
+}
+
+cleanup_fixture() {
+  rm -rf "$FIXTURE_ROOT"
+}
+
+Describe 'run-shellspec.sh'
+  Describe 'Given: a spec tree containing unit specs but no functional specs'
+    Before 'setup_fixture'
+    After 'cleanup_fixture'
+
+    Describe 'When: resolve_spec_files is called with a test type that has specs'
+      Describe 'Then: Task T-176-01 - a populated test type resolves successfully'
+        It 'exits with status 0'
+          When call resolve_in_fixture unit
+          The status should be success
+          The stdout should include 'sample.unit.spec.sh'
+        End
+
+        It 'lists the discovered spec file on stdout'
+          When call resolve_in_fixture unit
+          The stdout should include '__tests__/unit/sample.unit.spec.sh'
+        End
+      End
+    End
+
+    Describe 'When: resolve_spec_files is called with a test type that has no specs'
+      Describe 'Then: Task T-176-02 - an empty test type is an error, not a silent success'
+        It 'exits with non-zero status'
+          When call resolve_in_fixture functional
+          The status should be failure
+          The stderr should be present
+        End
+
+        It 'names the offending test type on stderr'
+          When call resolve_in_fixture functional
+          The status should be failure
+          The stderr should include "No spec files found for test type 'functional'"
+        End
+
+        It 'resolves no spec files on stdout'
+          When call resolve_in_fixture functional
+          The status should be failure
+          The stderr should be present
+          The stdout should equal ''
+        End
+      End
+    End
+
+    Describe 'When: resolve_spec_files is called with an unknown test type'
+      Describe 'Then: Task T-176-03 - a mistyped test type is rejected'
+        It 'exits with non-zero status'
+          When call resolve_in_fixture unti
+          The status should be failure
+          The stdout should be present
+        End
+
+        # The unknown-argument message is printed without a >&2 redirect, so at
+        # function level it lands on stdout; main() is what routes it to stderr.
+        It 'reports the unknown argument'
+          When call resolve_in_fixture unti
+          The status should be failure
+          The stdout should include "Unknown argument 'unti'"
+        End
+      End
+    End
+
+    Describe 'When: resolve_spec_files is called with a glob matching no files'
+      Describe 'Then: Task T-176-04 - an unmatched glob is an error'
+        It 'exits with non-zero status'
+          When call resolve_in_fixture './no/such/__tests__/unit/*.spec.sh'
+          The status should be failure
+          The stderr should be present
+        End
+
+        It 'names the offending pattern on stderr'
+          When call resolve_in_fixture './no/such/__tests__/unit/*.spec.sh'
+          The status should be failure
+          The stderr should include 'No spec files found matching glob'
+        End
+      End
+    End
+
+    Describe 'When: resolve_spec_files is called with a glob matching real files'
+      Describe 'Then: Task T-176-05 - a matching glob resolves successfully'
+        It 'exits with status 0 and lists the matched spec'
+          When call resolve_in_fixture '__tests__/unit/*.spec.sh'
+          The status should be success
+          The stdout should include 'sample.unit.spec.sh'
+        End
+      End
+    End
+
+    # Regression guard: this case set once narrowed to "system" alone. All three
+    # gate-opening types are asserted separately so that losing any one of them
+    # fails on its own line.
+    Describe 'When: resolve_spec_files is called with a type that opens the integration gate'
+      Describe 'Then: Task T-176-06 - integration, system and all clear SKIP_INTEGRATION_TESTS'
+        It 'clears the gate for the integration type'
+          When call gate_after_resolve integration
+          The stdout should equal '0'
+        End
+
+        It 'clears the gate for the system type'
+          When call gate_after_resolve system
+          The stdout should equal '0'
+        End
+
+        It 'clears the gate for the all type'
+          When call gate_after_resolve all
+          The stdout should equal '0'
+        End
+      End
+    End
+
+    Describe 'When: resolve_spec_files is called with a type outside the integration gate'
+      Describe 'Then: Task T-176-07 - unit leaves SKIP_INTEGRATION_TESTS closed'
+        It 'leaves the gate closed for the unit type'
+          When call gate_after_resolve unit
+          The stdout should equal '1'
+        End
+      End
+    End
+  End
+
+  # These two paths exit inside main() before shellspec is ever launched, so
+  # running the script directly is cheap and cannot recurse into this spec.
+  Describe 'Given: the runner is invoked with no spec selection'
+    Describe 'When: the script is run without arguments'
+      Describe 'Then: Task T-176-08 - a bare invocation is rejected'
+        It 'exits with non-zero status'
+          When run script "$_SCRIPT"
+          The status should be failure
+          The stderr should be present
+        End
+
+        It 'prints usage to stderr'
+          When run script "$_SCRIPT"
+          The status should be failure
+          The stderr should include 'Usage: run-shellspec.sh'
+        End
+      End
+    End
+
+    Describe 'When: the script is run with only an option and no test selection'
+      Describe 'Then: Task T-176-09 - an options-only invocation is rejected'
+        It 'exits with non-zero status'
+          When run script "$_SCRIPT" --integration
+          The status should be failure
+          The stderr should be present
+        End
+
+        It 'prints usage to stderr'
+          When run script "$_SCRIPT" --integration
+          The status should be failure
+          The stderr should include 'Usage: run-shellspec.sh'
+        End
+      End
+    End
+  End
+
+  Describe 'Given: the runner is pointed at a spec file that does not exist'
+    # resolve_spec_files accepts any *.spec.sh argument on suffix alone and does
+    # no existence check, so it succeeds here; the failure comes from shellspec
+    # rejecting the path further down. This is asserted end-to-end for that
+    # reason. Only the status and the stream are checked: shellspec's message is
+    # emitted with --color, so its text is ANSI-wrapped and brittle to match.
+    Describe 'When: the script is run with a missing spec path'
+      Describe 'Then: Task T-176-10 - a missing spec file fails the run'
+        It 'exits with non-zero status'
+          When run script "$_SCRIPT" './no/such/file.spec.sh'
+          The status should be failure
+          The stderr should be present
+        End
+      End
+    End
+  End
+End

--- a/runners/run-shellcheck.sh
+++ b/runners/run-shellcheck.sh
@@ -9,7 +9,7 @@
 
 set -euo pipefail
 
-# shellcheck disable=SC1091
+# shellcheck source=runners/libs/init-vars.lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/libs/init-vars.lib.sh"
 cd "${SCRIPT_ROOT}/.."
 

--- a/runners/run-shellspec.sh
+++ b/runners/run-shellspec.sh
@@ -18,8 +18,8 @@ SHELLSPEC="${SHELLSPEC:-${PROJECT_ROOT}/.tools/shellspec/shellspec}"
 
 readonly TEST_TYPES=("all" "unit" "functional" "integration" "system" "e2e")
 
-# Spec directory filter, matched as a substring against spec file paths
-readonly SPEC_ROOT_DIR="scripts/__tests__"
+# Directory name holding spec files, relative to each source tree
+readonly TEST_DIR_NAME="__tests__"
 
 SKIP_INTEGRATION_TESTS="${SKIP_INTEGRATION_TESTS:-1}"
 SPEC_SEARCH_ROOT="${SPEC_SEARCH_ROOT:-${PROJECT_ROOT}}"
@@ -61,8 +61,8 @@ expand_spec_glob() {
   )
 
   if [[ ${#matches[@]} -eq 0 ]]; then
-    echo "Warning: No spec files found matching glob '${pattern}'" >&2
-    return 0
+    echo "Error: No spec files found matching glob '${pattern}'" >&2
+    return 1
   fi
 
   local file
@@ -94,11 +94,24 @@ get_spec_files() {
   local test_type="$1"
   shift
 
+  # get_filelist applies these filters as unanchored regexes, so they have to be
+  # delimited as whole path components: the trailing separator keeps "unit" from
+  # matching "__tests__/unitary", and the leading one keeps "all" from matching
+  # "not__tests__". Both filters contain a separator, so each takes get_filelist's
+  # path-filter branch and is used as-is.
+  #
+  # Separators are written as [/] rather than a bare /: on Windows/Git Bash the
+  # MSYS argument path conversion rewrites a pattern shaped like /c/ before rg
+  # ever receives it (confirmed via MSYS_NO_PATHCONV), which silently matches
+  # nothing. A pattern starting with [ is left alone. This is not an rg defect.
+  #
+  # TEST_DIR_NAME and TEST_TYPES hold no regex metacharacters, so interpolating
+  # them directly is safe.
   local type_filter
   if [[ "$test_type" == "all" ]]; then
-    type_filter="${SPEC_ROOT_DIR}/"
+    type_filter="(^|[/])${TEST_DIR_NAME}[/]"
   else
-    type_filter="${SPEC_ROOT_DIR}/${test_type}/"
+    type_filter="(^|[/])${TEST_DIR_NAME}[/]${test_type}[/]"
   fi
 
   local -a spec_files
@@ -134,6 +147,13 @@ resolve_spec_files() {
     local -a expanded_specs
     mapfile -t expanded_specs < <(expand_spec_glob "$first_arg")
     mapfile -t RESOLVED_SPEC_FILES < <(filter_runnable_specs "${expanded_specs[@]}")
+    # mapfile masks expand_spec_glob's exit status, so the emptiness has to be
+    # re-checked here. mapfile yields either a zero-length array or a single
+    # empty element for empty input, hence both conditions.
+    if [[ ${#RESOLVED_SPEC_FILES[@]} -eq 0 || -z "${RESOLVED_SPEC_FILES[0]}" ]]; then
+      echo "Error: No runnable spec files found matching glob '${first_arg}'" >&2
+      return 1
+    fi
     shift
     SHELLSPEC_ARGS=("$@")
     printf '%s\n' "${RESOLVED_SPEC_FILES[@]}"
@@ -179,8 +199,8 @@ resolve_spec_files() {
   local -a spec_files
   mapfile -t spec_files < <(get_spec_files "$test_type" "${file_filters[@]}")
   if [[ ${#spec_files[@]} -eq 0 || -z "${spec_files[0]}" ]]; then
-    echo "Warning: No spec files found for test type '${test_type}'" >&2
-    return 0
+    echo "Error: No spec files found for test type '${test_type}'" >&2
+    return 1
   fi
 
   RESOLVED_SPEC_FILES=("${spec_files[@]}")
@@ -228,6 +248,14 @@ main() {
 
   parse_options "$@" >/dev/null
 
+  # Options-only invocation (e.g. "--integration") selects no specs. Running
+  # shellspec's default path here would report success without checking the
+  # specs the caller meant to run, so ask for an explicit selection instead.
+  if [[ ${#PARSED_ARGS[@]} -eq 0 ]]; then
+    usage >&2
+    exit 1
+  fi
+
   local resolved resolved_file
   resolved_file=$(mktemp)
   if ! resolve_spec_files "${PARSED_ARGS[@]}" >"$resolved_file"; then
@@ -236,10 +264,7 @@ main() {
     echo "$resolved" >&2
     exit 1
   fi
-  resolved=$(cat "$resolved_file")
   rm -f "$resolved_file"
-
-  [[ -z "$resolved" ]] && exit 0
 
   run_shellspec "${RESOLVED_SPEC_FILES[@]}" "${SHELLSPEC_ARGS[@]}"
 }

--- a/runners/run-shfmt.sh
+++ b/runners/run-shfmt.sh
@@ -10,6 +10,8 @@
 # shellcheck source=runners/libs/init-vars.lib.sh
 
 set -euo pipefail
+
+# shellcheck source=runners/libs/init-vars.lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/libs/init-vars.lib.sh"
 
 main() {


### PR DESCRIPTION
## Overview

**Summary**
Make `run-shellspec.sh` fail when a test type, file, or glob matches no spec files.

**Background / Motivation**
`run-shellspec.sh` exited 0 when spec discovery found nothing. A mistyped test type or a broken glob
reported success without running a single test.

`.shellspec` already sets `--fail-no-examples`, but the runner returned before shellspec started, so
that setting never took effect.

Exit code 0 should mean "checked, nothing wrong". Here it meant "checked nothing", and the two could
not be told apart. In CI only the green badge is seen; the warning on stderr is not read.

The repository already handles this the other way elsewhere. `.github/workflows/scripts/resolve-sha.sh`
fails instead of skipping, because skipping would let the lint pass silently. The runner was the one
place that did not.

Failing on every empty result would be wrong, so the fix depends on how the runner was called. A
selection the caller named must exist. `all` may still contain empty test types, since only `unit`
has specs today.

## Changes

### Core Changes

- `runners/run-shellspec.sh`
  - Replace `SPEC_ROOT_DIR="scripts/__tests__"` with `TEST_DIR_NAME="__tests__"`. Discovery now looks
    for the test directory in each source tree instead of one fixed path. This is what makes specs
    under `runners/__tests__/` visible.
  - Match the test type as `(^|[/])__tests__[/]<type>[/]` so path components are whole. `unit` no
    longer matches `__tests__/unitary`, and `all` no longer matches `not__tests__`. Separators are
    written `[/]` instead of `/` because on Windows and Git Bash, MSYS path conversion rewrites a
    `/c/`-shaped pattern before `rg` sees it, which matches nothing. A pattern starting with `[` is
    left alone. This is not an `rg` bug.
  - Change "no spec files found for test type" from a warning and `return 0` to an error and `return 1`.
  - Change "no spec files found matching glob" in `expand_spec_glob` the same way, and check for an
    empty result again in `resolve_spec_files`, because `mapfile` hides the exit status of the command
    it reads from.
  - Reject an options-only call such as `--integration`, which selects no specs. It now prints `usage`
    to stderr and exits 1. Running shellspec's default path here would report success without checking
    the specs the caller meant to run.
  - Remove the `[[ -z "$resolved" ]] && exit 0` early return in `main()`, the last path that turned an
    empty selection into a success.
- `runners/run-shellcheck.sh`, `runners/run-shfmt.sh`: add a `# shellcheck source=...` annotation on
  the `init-vars.lib.sh` source line. See Additional Notes.

### Test Updates

- `runners/__tests__/unit/run-shellspec.unit.spec.sh` (new, 243 lines) — the first spec file under
  `runners/`. It covers `resolve_spec_files` for a populated type, an empty type, an unknown type, a
  matching glob, an unmatched glob, and the `SKIP_INTEGRATION_TESTS` gate for `integration`, `system`,
  and `all` against `unit`. It also runs `run-shellspec.sh` end to end for the bare, options-only, and
  missing-path calls.

  Two points for review. The function-level cases source the script instead of running it: this spec
  sits under `__tests__/unit/`, so calling `run-shellspec.sh unit` from inside it would find and run
  this same file again without end. They also resolve against a `mktemp -d` fixture tree rather than
  the real repository, whose spec list changes as files are added — this file included — which would
  make the assertions drift.

### Removed

- The `SPEC_ROOT_DIR` constant, replaced by `TEST_DIR_NAME`.
- The `[[ -z "$resolved" ]] && exit 0` early return in `main()`.
- A redundant `# shellcheck disable=SC1091` in `runners/run-shellcheck.sh`.

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [x] Test
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Closes #176

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`) — `pnpm run lint:sh`
      (shellcheck) and `pnpm run check:sh` (shfmt) report nothing. `dprint check` does not apply here:
      no configured plugin covers `.sh`.
- [x] Tests pass (if test suite exists) — `pnpm run test:sh unit`: 50 examples, 0 failures.
- [ ] Documentation updated (for user-facing changes) — not needed. This is a behavior fix in the
      runner, and no document described the old behavior.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Breaking Change

Behavior changes, and this is the point of the fix. These calls used to exit 0 without running specs
and now exit non-zero:

- a test type with no spec files (`test:sh functional`)
- an unknown test type (`test:sh unti`)
- a file or glob that matches nothing
- a bare or options-only call

`test:sh all` and `test:sh unit` are unchanged. Anything relying on the old silent success will now
fail.

## Additional Notes

### Acceptance criteria were checked by running them

Every condition from #176 was run on this branch:

| Condition | Result |
| --- | --- |
| `test:sh functional` (empty type) | non-zero, `Error: No spec files found for test type 'functional'` |
| `test:sh unti` (unknown type) | non-zero, `Error: Unknown argument 'unti'.` |
| `test:sh all` with empty types present | exit 0 |
| missing file / unmatched glob | non-zero, both |
| `test:sh unit` (no regression) | exit 0, 50 examples, 0 failures |
| message identifies the empty type or pattern | yes, as shown above |

Failures come back as exit code 126 rather than 1, because they run through `pnpm run`. The criteria
ask for non-zero, so this meets them.

### Two shellcheck annotations are unrelated to #176

`runners/run-shellcheck.sh` and `runners/run-shfmt.sh` each get a `# shellcheck source=...` line, and
`run-shellcheck.sh` drops a `# shellcheck disable=SC1091` that is no longer needed. Two lines in
total, no behavior change, and not part of #176. Noted so the diff is not read as bugfix-only.

### An unmatched glob prints two error lines

The two lines are not duplicates. `expand_spec_glob` reports that the glob matched nothing. The
second check in `resolve_spec_files` also catches the case where the glob matched files but
`filter_runnable_specs` removed all of them, which happens with specs marked `# skip shellspec`.

### Results are from local runs

No CI job runs the ShellSpec suite yet, so the test, shellcheck, and shfmt results above come from
running them locally.
